### PR TITLE
Fix signup record creation with RLS

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -117,6 +117,7 @@ export class AuthService {
 
         if (profileError || roleError) {
           console.error('Profile creation error:', profileError || roleError);
+          return { user: null, error: (profileError || roleError) as AuthError };
         }
 
         const user = await this.mapSupabaseUserToUser(authData.user);

--- a/supabase/migrations/20250608_sign_up_rls.sql
+++ b/supabase/migrations/20250608_sign_up_rls.sql
@@ -1,0 +1,10 @@
+-- Allow authenticated users to insert their own records
+-- Add explicit INSERT policies so signup can create profiles and user roles
+
+-- Profiles table: allow users to insert a profile with their own id
+CREATE POLICY IF NOT EXISTS "Users can create own profile" ON public.profiles
+FOR INSERT WITH CHECK (id = auth.uid());
+
+-- User roles table: allow users to insert a role with their own user_id
+CREATE POLICY IF NOT EXISTS "Users can create own role" ON public.user_roles
+FOR INSERT WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- allow regular users to insert profiles and roles through new policies
- surface signup errors when profile creation fails

## Testing
- `npm install`
- `npm run lint` *(fails: 133 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844aede71a0832bbc071db8287a6d98