### PR TITLE
Use environment variables for Stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This project includes a small Node server for Stripe payment processing.
 Create a `.env` file in the project root with your keys:
 
 ```env
+VITE_STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
 STRIPE_SECRET_KEY=<your-secret-key>
 STRIPE_WEBHOOK_SECRET=<your-webhook-secret>
 ```

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,36 +1,16 @@
 import { loadStripe, Stripe } from '@stripe/stripe-js';
 
-// Environment configuration for Stripe keys
+// Stripe configuration derived from environment variables
 export const STRIPE_CONFIG = {
-  // Sandbox/Test keys (default)
-  test: {
-    publishableKey: 'pk_test_51RVFSSGadpjzVmLhDTISKngfxbFZkvwC2ZnuGIoH6GOWGBXnrtL40bQhPMp5mXY3QRCEdc4oUYmQ8XP51hEIlTvi00Hjel2rmB',
-    secretKey: 'sk_test_51RVFSSGadpjzVmLhpOgJLjgNBZxFDQCTnd92Id9GeZXQOpfuqpgLe2ShxNLmOh2jZxJ0GgBpIGTKqOkhc4iusUb800GWt9JLAu',
-    webhookSecret: 'whsec_hRCeos1p0nxmE5TViRMxslpBXq66NOmO'
-  },
-  // Production keys (to be set manually when going live)
-  production: {
-    publishableKey: process.env.VITE_STRIPE_PUBLISHABLE_KEY || '',
-    secretKey: process.env.STRIPE_SECRET_KEY || '',
-    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || ''
-  }
+  publishableKey: import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || '',
 };
 
-// Determine if we're in production based on environment
-const isProduction = process.env.NODE_ENV === 'production' && 
-                    process.env.VITE_STRIPE_PUBLISHABLE_KEY && 
-                    process.env.STRIPE_SECRET_KEY;
-
-// Get current configuration
-export const getCurrentStripeConfig = () => {
-  return isProduction ? STRIPE_CONFIG.production : STRIPE_CONFIG.test;
-};
+// Server-side secrets (not exposed in the client bundle)
+export const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || '';
+export const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET || '';
 
 // Get publishable key for frontend
-export const getStripePublishableKey = (): string => {
-  const config = getCurrentStripeConfig();
-  return config.publishableKey;
-};
+export const getStripePublishableKey = (): string => STRIPE_CONFIG.publishableKey;
 
 // Initialize Stripe instance
 let stripePromise: Promise<Stripe | null>;


### PR DESCRIPTION
## Summary
- remove test keys and rely on environment variables in `stripe.ts`
- document required Stripe variables in README

## Testing
- `npm run lint` *(fails: 133 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6844b7f8bdf0832b91d7c0919879f3d7