### PR TITLE
Implement audit log table and querying utilities

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -732,6 +732,39 @@ export type Database = {
           },
         ]
       }
+      audit_logs: {
+        Row: {
+          id: string
+          user_id: string | null
+          action: string
+          table_name: string
+          record_id: string | null
+          old_values: Json | null
+          new_values: Json | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          action: string
+          table_name: string
+          record_id?: string | null
+          old_values?: Json | null
+          new_values?: Json | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          action?: string
+          table_name?: string
+          record_id?: string | null
+          old_values?: Json | null
+          new_values?: Json | null
+          created_at?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -131,8 +131,20 @@ export class DatabaseService {
     oldValues?: any,
     newValues?: any
   ): Promise<void> {
-    // TODO: Implement audit logging when audit_logs table is created
-    console.log('Audit log:', { action, tableName, recordId, oldValues, newValues });
+    try {
+      const userId = await this.getCurrentUserId();
+
+      await supabase.from('audit_logs').insert({
+        user_id: userId,
+        action,
+        table_name: tableName,
+        record_id: recordId || null,
+        old_values: oldValues ? JSON.stringify(oldValues) : null,
+        new_values: newValues ? JSON.stringify(newValues) : null,
+      });
+    } catch (error) {
+      console.error('Failed to create audit log:', error);
+    }
   }
 
   /**

--- a/src/services/AuditLogService.ts
+++ b/src/services/AuditLogService.ts
@@ -1,0 +1,91 @@
+import { supabase } from '@/integrations/supabase/client';
+import { DatabaseService, DatabaseResponse, PaginationOptions, SortOptions } from '@/lib/database';
+
+export interface AuditLogFilters {
+  userId?: string;
+  action?: string;
+  tableName?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export class AuditLogService extends DatabaseService {
+  /**
+   * Retrieve audit logs (admin only)
+   */
+  async getAuditLogs(
+    filters?: AuditLogFilters,
+    pagination?: PaginationOptions,
+    sort?: SortOptions
+  ): Promise<DatabaseResponse<any[]>> {
+    const currentUserId = await this.getCurrentUserId();
+    if (!currentUserId) {
+      return {
+        data: null,
+        error: new Error('Niet geautoriseerd'),
+        success: false,
+      };
+    }
+
+    const hasPermission = await this.checkUserPermission(currentUserId, ['Manager']);
+    if (!hasPermission) {
+      return {
+        data: null,
+        error: new Error('Geen toegang tot audit logs'),
+        success: false,
+      };
+    }
+
+    return this.executeQuery(async () => {
+      let query = supabase.from('audit_logs').select('*');
+
+      if (filters?.userId) query = query.eq('user_id', filters.userId);
+      if (filters?.action) query = query.eq('action', filters.action);
+      if (filters?.tableName) query = query.eq('table_name', filters.tableName);
+      if (filters?.dateFrom) query = query.gte('created_at', filters.dateFrom);
+      if (filters?.dateTo) query = query.lte('created_at', filters.dateTo);
+
+      query = this.applySorting(query, sort || { column: 'created_at', ascending: false });
+      query = this.applyPagination(query, pagination);
+
+      const { data, error } = await query;
+      return { data, error };
+    });
+  }
+
+  /**
+   * Retrieve a single audit log by ID (admin only)
+   */
+  async getAuditLog(logId: string): Promise<DatabaseResponse<any>> {
+    const currentUserId = await this.getCurrentUserId();
+    if (!currentUserId) {
+      return {
+        data: null,
+        error: new Error('Niet geautoriseerd'),
+        success: false,
+      };
+    }
+
+    const hasPermission = await this.checkUserPermission(currentUserId, ['Manager']);
+    if (!hasPermission) {
+      return {
+        data: null,
+        error: new Error('Geen toegang tot audit logs'),
+        success: false,
+      };
+    }
+
+    return this.executeQuery(async () => {
+      const { data, error } = await supabase
+        .from('audit_logs')
+        .select('*')
+        .eq('id', logId)
+        .single();
+
+      return { data, error };
+    });
+  }
+}
+
+// Export singleton instance
+export const auditLogService = new AuditLogService();

--- a/supabase/migrations/20250609_create_audit_logs.sql
+++ b/supabase/migrations/20250609_create_audit_logs.sql
@@ -1,0 +1,23 @@
+-- Create audit_logs table for recording changes
+CREATE TABLE IF NOT EXISTS public.audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id),
+  action TEXT NOT NULL,
+  table_name TEXT NOT NULL,
+  record_id TEXT,
+  old_values JSONB,
+  new_values JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes to improve query performance
+CREATE INDEX IF NOT EXISTS idx_audit_logs_table ON public.audit_logs(table_name);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user ON public.audit_logs(user_id);
+
+-- Enable row level security
+ALTER TABLE public.audit_logs ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access
+DROP POLICY IF EXISTS "Service role can manage audit logs" ON public.audit_logs;
+CREATE POLICY "Service role can manage audit logs" ON public.audit_logs
+  FOR ALL USING (true);


### PR DESCRIPTION
## Summary
- create `audit_logs` table migration
- log audit events in the database instead of console
- expose `AuditLogService` for administrators
- update Supabase types

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844b7e64f78832bb44712ac416ff108