### PR TITLE
Move notifications to DB with realtime updates

### DIFF
--- a/CROSS_DASHBOARD_INTEGRATION_SUMMARY.md
+++ b/CROSS_DASHBOARD_INTEGRATION_SUMMARY.md
@@ -8,17 +8,17 @@ I have successfully implemented a comprehensive cross-dashboard integration syst
 
 ## 🏗️ **CORE ARCHITECTURE**
 
-### **1. Real-Time Notification System**
-- **Global Notification Store**: In-memory notification management with real-time listeners
+-### **1. Real-Time Notification System**
+- **Database-Persisted Notifications**: All notifications stored in Supabase and delivered in real-time
 - **Cross-Dashboard Communication**: Actions in one dashboard automatically notify relevant users in other dashboards
 - **Professional UI Component**: Notification bell with unread count, categorized notifications, and interactive management
 
 ### **2. Key Components Created**
 
-#### **📡 useNotifications Hook** (`src/hooks/useNotifications.ts`)
-- **Global State Management**: Centralized notification store with real-time updates
+-#### **📡 useNotifications Hook** (`src/hooks/useNotifications.ts`)
+- **Database Integration**: Reads and writes notifications via Supabase
 - **User-Specific Filtering**: Notifications filtered by user ID for personalized experience
-- **Real-Time Listeners**: Automatic UI updates when notifications are created/modified
+- **Real-Time Listeners**: Supabase channel subscriptions push new notifications instantly
 - **Notification Management**: Mark as read, delete, bulk operations
 - **Cross-Dashboard Helpers**: Pre-built functions for common notification scenarios
 
@@ -153,10 +153,10 @@ interface Notification {
 ```
 
 ### **Real-Time Update Mechanism**
-- **Global Listeners**: All dashboards subscribe to notification updates
+- **Supabase Channels**: Dashboards subscribe to `notifications` table events
 - **Automatic Filtering**: Notifications filtered by user ID for personalized experience
 - **Immediate UI Updates**: Real-time badge counts and notification lists
-- **Memory Efficient**: Lightweight in-memory store with cleanup capabilities
+- **Persistent Storage**: Data survives reloads and scales across instances
 
 ### **Cross-Dashboard Helper Functions**
 ```typescript
@@ -290,7 +290,7 @@ The cross-dashboard integration system is **immediately testable**:
 ### **🔧 TECHNICAL READINESS**
 - **Production Ready**: Clean, maintainable code with proper error handling
 - **Scalable Architecture**: Easy to extend with new notification types
-- **Performance Optimized**: Lightweight in-memory store with efficient updates
+- **Performance Optimized**: Database persistence with efficient real-time channels
 - **Type Safe**: Full TypeScript support prevents runtime errors
 
 ---

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,97 +1,90 @@
 import { useState, useEffect } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { useToast } from '@/hooks/use-toast';
+import { supabase } from '@/integrations/supabase/client';
+import { notificationService } from '@/services/NotificationService';
 
 export interface Notification {
   id: string;
-  userId: string;
-  type: 'document_uploaded' | 'document_approved' | 'document_rejected' | 'viewing_invitation' | 'application_received' | 'user_suspended' | 'issue_resolved';
+  user_id: string;
+  type: string;
   title: string;
   message: string;
   read: boolean;
-  createdAt: string;
-  data?: any;
+  created_at: string;
+  updated_at: string;
+  related_id?: string;
+  related_type?: string;
 }
-
-// Global notification store
-let globalNotifications: Notification[] = [];
-let notificationListeners: ((notifications: Notification[]) => void)[] = [];
-
-const notifyListeners = () => {
-  notificationListeners.forEach(listener => listener([...globalNotifications]));
-};
 
 export const useNotifications = () => {
   const { user } = useAuthStore();
   const { toast } = useToast();
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
+  const loadNotifications = async () => {
+    if (!user) return;
+    const result = await notificationService.getUserNotifications();
+    if (result.success && result.data) {
+      setNotifications(result.data as Notification[]);
+    }
+  };
+
+  useEffect(() => {
+    loadNotifications();
+  }, [user]);
+
   useEffect(() => {
     if (!user) return;
-
-    // Filter notifications for current user
-    const userNotifications = globalNotifications.filter(n => n.userId === user.id);
-    setNotifications(userNotifications);
-
-    // Add listener for real-time updates
-    const listener = (allNotifications: Notification[]) => {
-      const userNotifications = allNotifications.filter(n => n.userId === user.id);
-      setNotifications(userNotifications);
-    };
-
-    notificationListeners.push(listener);
+    const channel = supabase
+      .channel(`notifications-${user.id}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'notifications', filter: `user_id=eq.${user.id}` },
+        () => {
+          loadNotifications();
+        }
+      )
+      .subscribe();
 
     return () => {
-      const index = notificationListeners.indexOf(listener);
-      if (index > -1) {
-        notificationListeners.splice(index, 1);
-      }
+      supabase.removeChannel(channel);
     };
   }, [user]);
 
-  const createNotification = (notification: Omit<Notification, 'id' | 'createdAt' | 'read'>) => {
-    const newNotification: Notification = {
-      ...notification,
-      id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      createdAt: new Date().toISOString(),
-      read: false
-    };
+  const createNotification = async (data: { userId: string; type: string; title: string; message: string; relatedId?: string; relatedType?: string; }) => {
+    const result = await notificationService.createNotification({
+      userId: data.userId,
+      type: data.type,
+      title: data.title,
+      message: data.message,
+      relatedId: data.relatedId,
+      relatedType: data.relatedType
+    });
 
-    globalNotifications.unshift(newNotification);
-    notifyListeners();
-
-    // Show toast for real-time feedback
-    if (notification.userId === user?.id) {
-      toast({
-        title: notification.title,
-        description: notification.message
-      });
+    if (result.success && result.data) {
+      if (data.userId === user?.id) {
+        toast({ title: data.title, description: data.message });
+      }
+      await loadNotifications();
+      return result.data as Notification;
     }
-
-    return newNotification;
+    return null;
   };
 
-  const markAsRead = (notificationId: string) => {
-    const notification = globalNotifications.find(n => n.id === notificationId);
-    if (notification) {
-      notification.read = true;
-      notifyListeners();
-    }
+  const markAsRead = async (notificationId: string) => {
+    await notificationService.markAsRead(notificationId);
+    await loadNotifications();
   };
 
-  const markAllAsRead = () => {
-    globalNotifications
-      .filter(n => n.userId === user?.id)
-      .forEach(n => n.read = true);
-    notifyListeners();
+  const markAllAsRead = async () => {
+    await notificationService.markAllAsRead();
+    await loadNotifications();
   };
 
-  const deleteNotification = (notificationId: string) => {
-    const index = globalNotifications.findIndex(n => n.id === notificationId);
-    if (index > -1) {
-      globalNotifications.splice(index, 1);
-      notifyListeners();
-    }
+  const deleteNotification = async (notificationId: string) => {
+    await notificationService.deleteNotification(notificationId);
+    await loadNotifications();
   };
 
   const unreadCount = notifications.filter(n => !n.read).length;
@@ -108,141 +101,64 @@ export const useNotifications = () => {
 
 // Cross-dashboard notification helpers
 export const notifyDocumentUploaded = (uploaderName: string, documentType: string, beoordelaarId: string) => {
-  const notification: Omit<Notification, 'id' | 'createdAt' | 'read'> = {
+  notificationService.createNotification({
     userId: beoordelaarId,
     type: 'document_uploaded',
     title: 'Nieuw document te beoordelen',
-    message: `${uploaderName} heeft een ${documentType} document geüpload.`,
-    data: { uploaderName, documentType }
-  };
-
-  const newNotification: Notification = {
-    ...notification,
-    id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    createdAt: new Date().toISOString(),
-    read: false
-  };
-
-  globalNotifications.unshift(newNotification);
-  notifyListeners();
+    message: `${uploaderName} heeft een ${documentType} document geüpload.`
+  });
 };
 
 export const notifyDocumentApproved = (huurderName: string, documentType: string, huurderUserId: string) => {
-  const notification: Omit<Notification, 'id' | 'createdAt' | 'read'> = {
+  notificationService.createNotification({
     userId: huurderUserId,
     type: 'document_approved',
     title: 'Document goedgekeurd!',
-    message: `Je ${documentType} document is goedgekeurd en geverifieerd.`,
-    data: { documentType }
-  };
-
-  const newNotification: Notification = {
-    ...notification,
-    id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    createdAt: new Date().toISOString(),
-    read: false
-  };
-
-  globalNotifications.unshift(newNotification);
-  notifyListeners();
+    message: `Je ${documentType} document is goedgekeurd en geverifieerd.`
+  });
 };
 
 export const notifyDocumentRejected = (huurderName: string, documentType: string, reason: string, huurderUserId: string) => {
-  const notification: Omit<Notification, 'id' | 'createdAt' | 'read'> = {
+  notificationService.createNotification({
     userId: huurderUserId,
     type: 'document_rejected',
     title: 'Document afgewezen',
-    message: `Je ${documentType} document is afgewezen. Reden: ${reason}`,
-    data: { documentType, reason }
-  };
-
-  const newNotification: Notification = {
-    ...notification,
-    id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    createdAt: new Date().toISOString(),
-    read: false
-  };
-
-  globalNotifications.unshift(newNotification);
-  notifyListeners();
+    message: `Je ${documentType} document is afgewezen. Reden: ${reason}`
+  });
 };
 
 export const notifyViewingInvitation = (verhuurderName: string, propertyAddress: string, viewingDate: string, huurderUserId: string) => {
-  const notification: Omit<Notification, 'id' | 'createdAt' | 'read'> = {
+  notificationService.createNotification({
     userId: huurderUserId,
     type: 'viewing_invitation',
     title: 'Uitnodiging voor bezichtiging',
-    message: `${verhuurderName} nodigt je uit voor een bezichtiging van ${propertyAddress} op ${viewingDate}.`,
-    data: { verhuurderName, propertyAddress, viewingDate }
-  };
-
-  const newNotification: Notification = {
-    ...notification,
-    id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    createdAt: new Date().toISOString(),
-    read: false
-  };
-
-  globalNotifications.unshift(newNotification);
-  notifyListeners();
+    message: `${verhuurderName} nodigt je uit voor een bezichtiging van ${propertyAddress} op ${viewingDate}.`
+  });
 };
 
 export const notifyApplicationReceived = (huurderName: string, propertyAddress: string, verhuurderUserId: string) => {
-  const notification: Omit<Notification, 'id' | 'createdAt' | 'read'> = {
+  notificationService.createNotification({
     userId: verhuurderUserId,
     type: 'application_received',
     title: 'Nieuwe huuranvraag',
-    message: `${huurderName} heeft een aanvraag ingediend voor ${propertyAddress}.`,
-    data: { huurderName, propertyAddress }
-  };
-
-  const newNotification: Notification = {
-    ...notification,
-    id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    createdAt: new Date().toISOString(),
-    read: false
-  };
-
-  globalNotifications.unshift(newNotification);
-  notifyListeners();
+    message: `${huurderName} heeft een aanvraag ingediend voor ${propertyAddress}.`
+  });
 };
 
 export const notifyUserSuspended = (userName: string, reason: string, userId: string) => {
-  const notification: Omit<Notification, 'id' | 'createdAt' | 'read'> = {
+  notificationService.createNotification({
     userId: userId,
     type: 'user_suspended',
     title: 'Account geschorst',
-    message: `Je account is tijdelijk geschorst. Reden: ${reason}`,
-    data: { reason }
-  };
-
-  const newNotification: Notification = {
-    ...notification,
-    id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    createdAt: new Date().toISOString(),
-    read: false
-  };
-
-  globalNotifications.unshift(newNotification);
-  notifyListeners();
+    message: `Je account is tijdelijk geschorst. Reden: ${reason}`
+  });
 };
 
 export const notifyIssueResolved = (issueTitle: string, resolution: string, userId: string) => {
-  const notification: Omit<Notification, 'id' | 'createdAt' | 'read'> = {
+  notificationService.createNotification({
     userId: userId,
     type: 'issue_resolved',
     title: 'Issue opgelost',
-    message: `Je gemelde issue "${issueTitle}" is opgelost. ${resolution}`,
-    data: { issueTitle, resolution }
-  };
-
-  const newNotification: Notification = {
-    ...notification,
-    id: `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-    createdAt: new Date().toISOString(),
-    read: false
-  };
-
-  globalNotifications.unshift(newNotification);
-  notifyListeners();
+    message: `Je gemelde issue "${issueTitle}" is opgelost. ${resolution}`
+  });
 };


### PR DESCRIPTION
## Summary
- persist notifications in Supabase instead of using global state
- listen for realtime changes via Supabase channels
- deliver realtime toasts in `NotificationBell`
- update cross-dashboard documentation for new architecture

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b7e244a0832b88a8762b802a20e3