### PR TITLE
Remove ts-nocheck from PaymentService

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "node server.js"
+    "server": "node server.js",
+    "test": "node tests/paymentService.test.cjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/tests/paymentService.test.cjs
+++ b/tests/paymentService.test.cjs
@@ -1,0 +1,16 @@
+require('ts-node/register');
+const assert = require('node:assert');
+const { paymentService } = require('../src/services/PaymentService');
+
+try {
+  const infoHuurder = paymentService.getPricingInfo('huurder');
+  assert.equal(infoHuurder.interval, 'year');
+  assert.ok(infoHuurder.displayPrice.includes('€'));
+  const infoVerhuurder = paymentService.getPricingInfo('verhuurder');
+  assert.equal(infoVerhuurder.displayPrice, 'Gratis');
+  assert.equal(infoVerhuurder.actualPrice, 'Gratis');
+  console.log('paymentService tests passed');
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}

--- a/tests/paymentService.test.ts
+++ b/tests/paymentService.test.ts
@@ -1,0 +1,16 @@
+import { strict as assert } from 'node:assert';
+import { paymentService } from '../src/services/PaymentService';
+
+// Basic unit tests for getPricingInfo
+try {
+  const infoHuurder = paymentService.getPricingInfo('huurder');
+  assert.equal(infoHuurder.interval, 'year');
+  assert.ok(infoHuurder.displayPrice.includes('€'));
+  const infoVerhuurder = paymentService.getPricingInfo('verhuurder');
+  assert.equal(infoVerhuurder.displayPrice, 'Gratis');
+  assert.equal(infoVerhuurder.actualPrice, 'Gratis');
+  console.log('paymentService tests passed');
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- enable TS checking in `PaymentService`
- align types with Supabase and remove ignores
- add basic tests for pricing info
- wire `npm test` script

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: ESLint config issues)*
- `npm test` *(fails: ERR_REQUIRE_ESM when importing TS modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844b7fd696c832b965960bf56a950b6