### PR TITLE
Implement cookie consent banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { HuurderRoute, VerhuurderRoute, BeoordelaarRoute, BeheerderRoute } from "@/components/auth/ProtectedRoute";
 import { config } from "@/lib/config";
 import { Skeleton } from "@/components/ui/skeleton";
+import CookieConsent from "@/components/CookieConsent";
 
 // Lazy load pages for better performance
 const Index = lazy(() => import("./pages/Index"));
@@ -86,6 +87,7 @@ const App = () => (
             <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>
+        <CookieConsent />
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+const CONSENT_KEY = "cookie_consent";
+
+const CookieConsent = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(CONSENT_KEY);
+    if (!stored) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem(CONSENT_KEY, "accepted");
+    setVisible(false);
+  };
+
+  const decline = () => {
+    localStorage.setItem(CONSENT_KEY, "declined");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 border-t bg-white p-4 shadow">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-gray-700">
+          Huurly gebruikt cookies om de gebruikerservaring te verbeteren. Lees ons{" "}
+          <Link to="/privacybeleid" className="underline">
+            privacybeleid
+          </Link>
+          .
+        </p>
+        <div className="flex gap-2 justify-end">
+          <Button variant="secondary" onClick={decline}>
+            Weigeren
+          </Button>
+          <Button onClick={accept}>Accepteren</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsent;

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -81,8 +81,12 @@ const SidebarProvider = React.forwardRef<
           _setOpen(openState)
         }
 
-        // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+        // Only set the cookie when the user has accepted cookies.
+        try {
+          if (localStorage.getItem("cookie_consent") === "accepted") {
+            document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+          }
+        } catch {}
       },
       [setOpenProp, open]
     )


### PR DESCRIPTION
## Summary
- create `CookieConsent` component that stores consent in localStorage
- add cookie banner to the root layout so it's shown on every page
- only set sidebar state cookie when consent is granted

## Testing
- `npm run lint` *(fails: various lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844bb07086c832bb06e338fb863850b