### PR TITLE
Fix server setup and logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "node server.js",
+    "server": "node server.cjs",
     "test": "node tests/paymentService.test.cjs"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- rename `server.js` -> `server.cjs`
- use `ts-node/register` and import project logger
- replace `console` calls with `logger`
- update npm server script

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register' / ERR_REQUIRE_ESM)*

------
https://chatgpt.com/codex/tasks/task_e_6845366869c4832b93f8d66586c645d2