### PR TITLE
Add runtime-aware pino logger

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,5 +1,11 @@
 import pino from 'pino';
+
 const isBrowser = typeof window !== 'undefined';
+
+/** Shared logger instance that works in both the browser and Node.js. */
 export const logger = isBrowser
-  ? pino({ browser: { asObject: true }, level: 'info' })
-  : pino({ transport: { target: 'pino-pretty' }, level: process.env.LOG_LEVEL || 'info' });
+  ? pino({ browser: { asObject: true } })
+  : pino({ transport: { target: 'pino-pretty' } });
+
+// Convenience re-exports of common logging methods
+export const { info, error, warn, debug, fatal } = logger;


### PR DESCRIPTION
## Summary
- add a runtime aware logger that works in node and browser
- re-export logging convenience methods

## Testing
- `npm test` *(fails: ERR_REQUIRE_ESM)*

------
https://chatgpt.com/codex/tasks/task_e_68453b131e90832b8a5bd9405a014aee