### PR TITLE
Use env vars for Supabase scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ npm i
 npm run dev
 ```
 
+## Database Scripts
+
+The scripts in `src/scripts` interact directly with your Supabase project. They
+expect the following environment variables to be set before running:
+
+```env
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_SERVICE_KEY=<your-supabase-service-key>
+```
+
+Place these variables in a `.env` file or export them in your shell so that
+`update-db.ts` and `query-roles.ts` can authenticate properly.
+
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).
@@ -107,3 +121,17 @@ Then in a separate terminal run:
 ```sh
 npm run dev
 ```
+
+
+## Database Scripts
+
+The scripts in `src/scripts` interact directly with your Supabase project. They
+expect the following environment variables to be set before running:
+
+```env
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_SERVICE_KEY=<your-supabase-service-key>
+```
+
+Place these variables in a `.env` file or export them in your shell so that
+`update-db.ts` and `query-roles.ts` can authenticate properly.

--- a/src/scripts/query-roles.ts
+++ b/src/scripts/query-roles.ts
@@ -1,9 +1,14 @@
 const { createClient } = require('@supabase/supabase-js');
 const { logger } = require('../lib/logger');
-const SUPABASE_URL = "https://lxtkotgfsnahwncgcfnl.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx4dGtvdGdmc25haHduY2djZm5sIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkwMjU4MjgsImV4cCI6MjA2NDYwMTgyOH0.3ukJCXs7f1HOO7y7ZgfpnSIalolB1LYbFpRtLd6ZyNE";
+const dotenv = require('dotenv');
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+// This script requires SUPABASE_URL and SUPABASE_SERVICE_KEY in the environment.
+dotenv.config();
+
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY || '';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
 async function queryUserRoles() {
   try {

--- a/src/scripts/update-db.ts
+++ b/src/scripts/update-db.ts
@@ -1,11 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 import type { PostgrestError } from '@supabase/supabase-js';
 import { logger } from '../lib/logger';
+import dotenv from 'dotenv';
 
-const SUPABASE_URL = "https://lxtkotgfsnahwncgcfnl.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx4dGtvdGdmc25haHduY2djZm5sIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkwMjU4MjgsImV4cCI6MjA2NDYwMTgyOH0.3ukJCXs7f1HOO7y7ZgfpnSIalolB1LYbFpRtLd6ZyNE";
+// This script requires SUPABASE_URL and SUPABASE_SERVICE_KEY in the environment.
+dotenv.config();
 
-const supabase = createClient<PostgrestError>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY || '';
+
+const supabase = createClient<PostgrestError>(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
 // Function to execute raw SQL queries
 async function executeRawSQL(sql: string): Promise<{ data: any; error: PostgrestError | null }> {


### PR DESCRIPTION
## Summary
- read Supabase credentials from `.env` in `update-db.ts` and `query-roles.ts`
- document required environment variables in the README

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68455a5ada10832badd5cdd535c9bf4f