### PR TITLE
Update env usage and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,22 @@ Before building the project or running tests, install the dependencies:
 npm install
 ```
 
+
 The application relies on all environment variables defined in `.env.example`. If any of these are missing the site may render a blank page. Tests can also fail when `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` are not provided.
+
+## Environment Variables
+
+Create a `.env` file in the project root and provide the following keys:
+
+```env
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+VITE_STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
+STRIPE_SECRET_KEY=<your-secret-key>
+STRIPE_WEBHOOK_SECRET=<your-webhook-secret>
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_SERVICE_KEY=<your-service-key>
+```
 
 
 ## How can I deploy this project?

--- a/src/data/demoData.ts
+++ b/src/data/demoData.ts
@@ -4,6 +4,7 @@
  */
 
 import { User, TenantProfile, LandlordProfile, Property, Document, ViewingInvitation, Issue } from '@/types';
+import { getEnvVar } from '@/lib/env';
 
 // Demo users for login credentials (preserved for testing)
 export const demoUsers: User[] = [
@@ -297,7 +298,7 @@ export const demoStatistics = {
 
 // Helper function to check if we're in demo mode
 export const isDemoMode = (): boolean => {
-  return import.meta.env.VITE_DEMO_MODE === 'true';
+  return getEnvVar('VITE_DEMO_MODE') === 'true';
 };
 
 // Empty state messages for clean UI


### PR DESCRIPTION
## Summary
- use `getEnvVar` in demo data util
- document required environment variables in README

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68455dea6d14832bbb8010314afc866f