### PR TITLE
Use getEnvVar in config

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,8 +2,8 @@
  * Centralized configuration management
  * Handles environment variables and application settings
  */
-import { logger } from '@/lib/logger';
-import { getEnvVar, isBrowser } from '@/lib/env';
+import { logger } from './logger';
+import { getEnvVar, isBrowser } from './env';
 
 export interface AppConfig {
   app: {


### PR DESCRIPTION
## Summary
- refactor config.ts to use local imports instead of project aliases for Node compatibility
- ensure environment variable values are loaded through `getEnvVar`

## Testing
- `npm test`
- `node --experimental-specifier-resolution=node --loader ts-node/esm -r tsconfig-paths/register -e "import('./src/lib/config.ts').then(m=>console.log('name', m.config.app.name)).catch(err=>console.error('err', err))"`

------
https://chatgpt.com/codex/tasks/task_e_68455dfe4b38832bbb968fc662f77da7