### PR TITLE
Add dotenv setup and clarify env vars for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ expect the following environment variables to be set before running:
 ```env
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_SERVICE_KEY=<your-supabase-service-key>
+SUPABASE_PUBLISHABLE_KEY=<your-supabase-publishable-key>
 ```
 
 Place these variables in a `.env` file or export them in your shell so that
-`update-db.ts` and `query-roles.ts` can authenticate properly.
+`update-db.ts` (uses `SUPABASE_SERVICE_KEY`) and `query-roles.ts` (uses
+`SUPABASE_PUBLISHABLE_KEY`) can authenticate properly.
 
 
 **Edit a file directly in GitHub**
@@ -131,7 +133,9 @@ expect the following environment variables to be set before running:
 ```env
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_SERVICE_KEY=<your-supabase-service-key>
+SUPABASE_PUBLISHABLE_KEY=<your-supabase-publishable-key>
 ```
 
 Place these variables in a `.env` file or export them in your shell so that
-`update-db.ts` and `query-roles.ts` can authenticate properly.
+`update-db.ts` (uses `SUPABASE_SERVICE_KEY`) and `query-roles.ts` (uses
+`SUPABASE_PUBLISHABLE_KEY`) can authenticate properly.

--- a/src/scripts/query-roles.ts
+++ b/src/scripts/query-roles.ts
@@ -1,14 +1,14 @@
-const { createClient } = require('@supabase/supabase-js');
-const { logger } = require('../lib/logger');
-const dotenv = require('dotenv');
+import { createClient } from '@supabase/supabase-js';
+import { logger } from '../lib/logger';
+import dotenv from 'dotenv';
 
-// This script requires SUPABASE_URL and SUPABASE_SERVICE_KEY in the environment.
+// This script requires SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY in the environment.
 dotenv.config();
 
 const SUPABASE_URL = process.env.SUPABASE_URL || '';
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY || '';
+const SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY || '';
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+const supabase = createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
 
 async function queryUserRoles() {
   try {


### PR DESCRIPTION
## Summary
- import dotenv in `query-roles.ts` using ESM syntax
- read `SUPABASE_PUBLISHABLE_KEY` from the environment
- document all required variables for running the DB scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68455dfe68a0832b8fa25f0c99e40d2d