### PR TITLE
Fix duplicate DB script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,6 @@ npm i
 npm run dev
 ```
 
-## Database Scripts
-
-The scripts in `src/scripts` interact directly with your Supabase project. They
-expect the following environment variables to be set before running:
-
-```env
-SUPABASE_URL=<your-supabase-url>
-SUPABASE_SERVICE_KEY=<your-supabase-service-key>
-SUPABASE_PUBLISHABLE_KEY=<your-supabase-publishable-key>
-```
-
-Place these variables in a `.env` file or export them in your shell so that
-`update-db.ts` (uses `SUPABASE_SERVICE_KEY`) and `query-roles.ts` (uses
-`SUPABASE_PUBLISHABLE_KEY`) can authenticate properly.
 
 
 **Edit a file directly in GitHub**


### PR DESCRIPTION
## Summary
- deduplicate `Database Scripts` section in README

## Testing
- `npm test` *(fails: cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_684568fbf5cc832bb92354b73861454e