### PR TITLE
Remove Manager role from Supabase

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -752,7 +752,6 @@ export type Database = {
       user_role:
         | "Huurder"
         | "Verhuurder"
-        | "Manager"
         | "Beheerder"
         | "Beoordelaar"
     }
@@ -875,7 +874,6 @@ export const Constants = {
       user_role: [
         "Huurder",
         "Verhuurder",
-        "Manager",
         "Beheerder",
         "Beoordelaar",
       ],

--- a/src/scripts/update-db.ts
+++ b/src/scripts/update-db.ts
@@ -25,9 +25,22 @@ async function executeRawSQL(sql: string): Promise<{ data: any; error: Postgrest
 }
 
 async function main() {
-  // SQL to alter the enum in the database
+  // SQL to drop the 'Manager' value from the enum
   const sql = `
-  ALTER TYPE public.user_role ADD VALUES ('Beoordelaar', 'Beheerder');
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM pg_type WHERE typname = 'user_role'
+        AND 'Manager' = ANY(enum_range(NULL::user_role))
+    ) THEN
+      ALTER TYPE public.user_role RENAME TO user_role_old;
+      CREATE TYPE public.user_role AS ENUM ('Huurder', 'Verhuurder', 'Beheerder', 'Beoordelaar');
+      ALTER TABLE public.user_roles
+        ALTER COLUMN role TYPE public.user_role USING role::text::public.user_role;
+      DROP TYPE public.user_role_old;
+    END IF;
+  END
+  $$;
   `;
 
   try {

--- a/supabase/migrations/20250610_remove_manager_role.sql
+++ b/supabase/migrations/20250610_remove_manager_role.sql
@@ -1,0 +1,14 @@
+-- Remove 'Manager' value from user_role enum
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'user_role'
+      AND 'Manager' = ANY(enum_range(NULL::user_role))
+  ) THEN
+    ALTER TYPE public.user_role RENAME TO user_role_old;
+    CREATE TYPE public.user_role AS ENUM ('Huurder', 'Verhuurder', 'Beheerder', 'Beoordelaar');
+    ALTER TABLE public.user_roles
+      ALTER COLUMN role TYPE public.user_role USING role::text::public.user_role;
+    DROP TYPE public.user_role_old;
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary
- drop `Manager` from the `user_role` enum in DB
- update enum references in generated Supabase types
- update DB update script to remove `Manager`
- add migration to update enum

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684577139d10832bbba2f45062fd72ba