### PR TITLE
Replace Manager role with Beheerder

### DIFF
--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -315,7 +315,7 @@ export class PaymentService extends DatabaseService {
       const { data: managers } = await supabase
         .from('user_roles')
         .select('user_id')
-        .eq('role', 'Manager');
+        .eq('role', 'Beheerder');
 
       if (managers) {
         const notifications = managers.map(manager => ({

--- a/src/services/PropertyService.ts
+++ b/src/services/PropertyService.ts
@@ -78,7 +78,7 @@ export class PropertyService extends DatabaseService {
     }
 
     // Check if user is a landlord
-    const hasPermission = await this.checkUserPermission(currentUserId, ['Verhuurder', 'Manager']);
+    const hasPermission = await this.checkUserPermission(currentUserId, ['Verhuurder', 'Beheerder']);
     if (!hasPermission) {
       return {
         data: null,

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -178,7 +178,7 @@ export class UserService extends DatabaseService {
    */
   async updateUserRole(
     userId: string,
-    role: 'Huurder' | 'Verhuurder' | 'Manager'
+    role: 'Huurder' | 'Verhuurder' | 'Beoordelaar' | 'Beheerder'
   ): Promise<DatabaseResponse<Tables<'user_roles'>>> {
     const hasPermission = await this.checkUserPermission(userId, ['Beheerder']);
     if (!hasPermission) {
@@ -252,7 +252,7 @@ export class UserService extends DatabaseService {
       // Apply filters
       if (filters?.role) {
         // Map frontend role to database role
-        let dbRole: 'Huurder' | 'Verhuurder' | 'Manager';
+        let dbRole: 'Huurder' | 'Verhuurder' | 'Beoordelaar' | 'Beheerder';
         switch (filters.role) {
           case 'huurder':
             dbRole = 'Huurder';
@@ -261,8 +261,10 @@ export class UserService extends DatabaseService {
             dbRole = 'Verhuurder';
             break;
           case 'beoordelaar':
+            dbRole = 'Beoordelaar';
+            break;
           case 'beheerder':
-            dbRole = 'Manager';
+            dbRole = 'Beheerder';
             break;
           default:
             dbRole = 'Huurder';

--- a/src/services/ViewingService.ts
+++ b/src/services/ViewingService.ts
@@ -252,7 +252,7 @@ export class ViewingService extends DatabaseService {
         .eq('user_id', currentUserId)
         .single();
 
-      if (userRole?.role !== 'Manager') {
+      if (userRole?.role !== 'Beheerder') {
         query = query.or(`tenant_id.eq.${currentUserId},landlord_id.eq.${currentUserId}`);
       }
 


### PR DESCRIPTION
## Summary
- remove old Manager role usage in services
- map user roles to only `Huurder`, `Verhuurder`, `Beoordelaar`, and `Beheerder`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845810ed654832ba4ceac8fab48d368