### PR TITLE
Fix transparent dialog backgrounds

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,27 @@
   --dutch-blue: #21409a;
   --dutch-orange: #ff6600;
   --dutch-red: #ae1c28;
+  /* Base colors for shadcn-ui components */
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 100% 50%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+  --radius: 0.5rem;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- define shadcn-ui CSS variables including `--background`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68458303dba4832ba5ef34fe01461cb2