### PR TITLE
Add redirect on Index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,8 +4,33 @@ import { Hero } from '@/components/Hero';
 import { Features } from '@/components/Features';
 import { CTA } from '@/components/CTA';
 import { Logo } from '@/components/Logo';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 
 const Index = () => {
+  const { user, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isAuthenticated && user) {
+      switch (user.role) {
+        case 'huurder':
+          navigate('/huurder-dashboard');
+          break;
+        case 'verhuurder':
+          navigate('/verhuurder-dashboard');
+          break;
+        case 'beoordelaar':
+          navigate('/beoordelaar-dashboard');
+          break;
+        case 'beheerder':
+          navigate('/beheerder-dashboard');
+          break;
+      }
+    }
+  }, [isAuthenticated, user, navigate]);
+
   return (
     <div className="min-h-screen">
       <Header />


### PR DESCRIPTION
## Summary
- invoke `useAuth` in `Index.tsx`
- navigate to the proper dashboard when a user is already authenticated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c818c9a4832bad072a51d95e85ff