### PR TITLE
Install cross-env and update server/test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ SUPABASE_URL=<your-supabase-url>
 SUPABASE_SERVICE_KEY=<your-supabase-service-key>
 ```
 
-Start the Stripe server alongside the Vite dev server:
+Start the Stripe server alongside the Vite dev server. The `server` script uses `cross-env`,
+so it works on all platforms:
 
 ```sh
 npm run server

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
+        "cross-env": "^7.0.3",
         "date-fns": "^3.6.0",
         "dotenv": "^16.5.0",
         "embla-carousel-react": "^8.3.0",
@@ -4132,6 +4133,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm server.ts",
-    "test": "VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm tests/paymentService.test.ts"
+    "server": "cross-env TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm server.ts",
+    "test": "cross-env VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm tests/paymentService.test.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -47,6 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "cross-env": "^7.0.3",
     "date-fns": "^3.6.0",
     "dotenv": "^16.5.0",
     "embla-carousel-react": "^8.3.0",
@@ -66,10 +67,10 @@
     "stripe": "^18.2.1",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "ts-node": "^10.9.2",
     "vaul": "^0.9.3",
     "zod": "^3.23.8",
-    "zustand": "^5.0.5",
-    "ts-node": "^10.9.2"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
## Summary
- add `cross-env` dependency
- run `npm install` to update lockfile
- update `server` and `test` scripts to use cross-env
- document cross-platform server command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68468d730b98832b84e6d4cb4b3577f3