### PR TITLE
Add payment success page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const AlgemeneVoorwaarden = lazy(() => import("./pages/AlgemeneVoorwaarden"));
 const Privacybeleid = lazy(() => import("./pages/Privacybeleid"));
 const Unauthorized = lazy(() => import("./pages/Unauthorized"));
 const PaymentRequired = lazy(() => import("./pages/PaymentRequired"));
+const PaymentSuccess = lazy(() => import("./pages/PaymentSuccess"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient({
@@ -84,6 +85,7 @@ const App = () => (
             <Route path="/privacybeleid" element={<Privacybeleid />} />
             <Route path="/unauthorized" element={<Unauthorized />} />
             <Route path="/payment-required" element={<PaymentRequired />} />
+            <Route path="/payment-success" element={<PaymentSuccess />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { CheckCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+const PaymentSuccess = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <Card className="max-w-md w-full text-center">
+        <CardHeader>
+          <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <CardTitle className="text-2xl">Betaling geslaagd</CardTitle>
+          <CardDescription>Je betaling is succesvol verwerkt.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button className="w-full" onClick={() => navigate('/huurder-dashboard')}>
+            Ga naar dashboard
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default PaymentSuccess;


### PR DESCRIPTION
## Summary
- add a PaymentSuccess page with a success card
- wire the new page in the router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae78915d4832bbb172326d95530a0