### PR TITLE
Add PaymentSuccess route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const AlgemeneVoorwaarden = lazy(() => import("./pages/AlgemeneVoorwaarden"));
 const Privacybeleid = lazy(() => import("./pages/Privacybeleid"));
 const Unauthorized = lazy(() => import("./pages/Unauthorized"));
 const PaymentRequired = lazy(() => import("./pages/PaymentRequired"));
+const PaymentSuccess = lazy(() => import("./pages/PaymentSuccess"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient({
@@ -84,6 +85,7 @@ const App = () => (
             <Route path="/privacybeleid" element={<Privacybeleid />} />
             <Route path="/unauthorized" element={<Unauthorized />} />
             <Route path="/payment-required" element={<PaymentRequired />} />
+            <Route path="/payment-success" element={<PaymentSuccess />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+import { CheckCircle } from 'lucide-react';
+
+const PaymentSuccess = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full text-center">
+        <div className="bg-white rounded-lg shadow-lg p-8">
+          <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">Betaling gelukt</h1>
+          <p className="text-gray-600 mb-6">
+            Bedankt voor je betaling! Je abonnement is nu actief.
+          </p>
+          <Button onClick={() => navigate('/')} className="w-full">
+            Ga naar home
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentSuccess;


### PR DESCRIPTION
## Summary
- lazy load `PaymentSuccess`
- route `/payment-success` before catch-all
- provide `PaymentSuccess` page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae789f840832bb61af5a407c962ec