### PR TITLE
Fix Stripe success URL

### DIFF
--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -34,11 +34,11 @@ export const PaymentModal = ({
 
   const handlePayment = () => {
     // Redirect to payment success page instead of dashboard with payment param
-    window.location.href =
-      "https://buy.stripe.com/test_14A4gz3NMaRW2vRfHm9MY00?locale=nl&success_url=" + 
-      encodeURIComponent(`${window.location.origin}/payment-success?session_id={CHECKOUT_SESSION_ID}`) +
-      "&cancel_url=" + 
-      encodeURIComponent(`${window.location.origin}/huurder-dashboard?payment=cancelled`);
+      window.location.href =
+        "https://buy.stripe.com/test_14A4gz3NMaRW2vRfHm9MY00?locale=nl&success_url=" +
+        `${window.location.origin}/payment-success?session_id={CHECKOUT_SESSION_ID}` +
+        "&cancel_url=" +
+        encodeURIComponent(`${window.location.origin}/huurder-dashboard?payment=cancelled`);
   };
 
   const Content = persistent ? PersistentDialogContent : DialogContent;

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -67,7 +67,7 @@ export class PaymentService extends DatabaseService {
           userId: userId,
           userEmail: user.email,
           paymentRecordId: paymentRecord.id,
-          successUrl: `${window.location.origin}/payment-success`,
+          successUrl: `${window.location.origin}/payment-success?session_id={CHECKOUT_SESSION_ID}`,
           cancelUrl: `${window.location.origin}/huurder-dashboard?payment=cancelled`,
         },
       });


### PR DESCRIPTION
## Summary
- include Stripe session placeholder when creating checkout session
- adjust PaymentModal link so Stripe can fill in the checkout session id

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c06303e20832bb68b434a657a5894