### PR TITLE
Fix user role retrieval logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "cross-env VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm tests/paymentService.test.ts",
+    "test": "cross-env VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm tests/paymentService.test.ts && cross-env VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=anon TS_NODE_TRANSPILE_ONLY=true node --loader ts-node/esm tests/userMapper.test.ts",
     "generate-types": "npx supabase gen types typescript --project-id sqhultitvpivlnlgogen > src/types/database.ts"
   },
   "dependencies": {

--- a/src/lib/auth/userMapper.ts
+++ b/src/lib/auth/userMapper.ts
@@ -4,7 +4,6 @@ import { User } from '@/types';
 import { User as SupabaseUser } from '@supabase/supabase-js';
 import { logger } from '@/lib/logger';
 import { roleMapper } from './roleMapper';
-import { paymentChecker } from './paymentChecker';
 
 class UserMapper {
   /**
@@ -15,12 +14,12 @@ class UserMapper {
       // Get profile data
       const { data: profileData } = await supabase
         .from('gebruikers')
-        .select('naam, rol')
+        .select('naam, rol, abonnementen(status)')
         .eq('id', supabaseUser.id)
         .single();
 
-      // Check payment status
-      const hasPayment = await paymentChecker.checkPaymentStatus(supabaseUser.id);
+      // Determine payment status from abonnementen join
+      const hasPayment = profileData?.abonnementen?.status === 'actief';
 
       const name = profileData?.naam || `${supabaseUser.user_metadata?.first_name || ''} ${supabaseUser.user_metadata?.last_name || ''}`.trim() || supabaseUser.email?.split('@')[0] || 'User';
 

--- a/tests/userMapper.test.ts
+++ b/tests/userMapper.test.ts
@@ -1,0 +1,36 @@
+import { strict as assert } from 'node:assert';
+import { userMapper } from '../src/lib/auth/userMapper.ts';
+import { supabase } from '../src/integrations/supabase/client.ts';
+
+// Mock supabase "from" chain to return role data without hitting network
+const originalFrom = supabase.from.bind(supabase);
+
+// Simple supabase.from stub
+supabase.from = function(table: string) {
+  assert.equal(table, 'gebruikers');
+  return {
+    select() { return this; },
+    eq() { return this; },
+    single() {
+      return Promise.resolve({ data: { naam: 'Test', rol: 'huurder', abonnementen: { status: 'actief' } } });
+    }
+  } as any;
+};
+
+const supabaseUser = {
+  id: '123',
+  email: 'test@example.com',
+  user_metadata: {},
+  email_confirmed_at: 'now',
+  created_at: 'now'
+} as any;
+
+(async () => {
+  const user = await userMapper.mapSupabaseUserToUser(supabaseUser);
+  assert.equal(user.role, 'huurder');
+  assert.equal(user.hasPayment, true);
+  console.log('userMapper tests passed');
+})();
+
+// Restore original
+supabase.from = originalFrom;


### PR DESCRIPTION
## Summary
- join `abonnementen` when mapping a Supabase user
- add basic unit test for role mapping
- run both tests via npm script

## Testing
- `npm test` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68599ce26678832b838e39fdd3b02386