### PR TITLE
Implement property matching and add tests

### DIFF
--- a/src/services/MatchingService.ts
+++ b/src/services/MatchingService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '../integrations/supabase/client';
 
 export class MatchingService {
   static async getMatches(tenantId: string) {
@@ -13,25 +13,19 @@ export class MatchingService {
 
       if (tenantError) throw tenantError;
 
-      // For now, return empty array since properties table doesn't exist
-      // TODO: Implement proper matching when properties table is available
-      console.log('MatchingService: Properties table not available, returning empty matches');
-      return [];
-
-      // This would be the proper implementation when properties table exists:
-      /*
       const { data: properties, error: propertiesError } = await supabase
         .from('panden')
         .select('*')
-        .gte('huurprijs', tenant.min_budget || 0)
-        .lte('huurprijs', tenant.max_budget || 999999)
-        .eq('stad', tenant.voorkeur_stad || '')
-        .gte('aantal_slaapkamers', tenant.voorkeur_aantal_slaapkamers || 1);
+        .gte('huurprijs', tenant.min_budget ?? 0)
+        .lte('huurprijs', tenant.max_budget ?? Number.MAX_SAFE_INTEGER)
+        .eq('stad', tenant.voorkeur_stad ?? '')
+        .eq('type', tenant.voorkeur_woningtype ?? '')
+        .eq('gemeubileerd', tenant.voorkeur_gemeubileerd ?? '')
+        .gte('aantal_slaapkamers', tenant.voorkeur_aantal_slaapkamers ?? 1);
 
       if (propertiesError) throw propertiesError;
 
       return properties || [];
-      */
     } catch (error) {
       console.error('Error getting matches:', error);
       return [];

--- a/tests/matchingService.test.ts
+++ b/tests/matchingService.test.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert';
+import { MatchingService } from '../src/services/MatchingService.ts';
+
+// Sample tenant and property to verify match score logic
+const tenant = {
+  min_budget: 1000,
+  max_budget: 2000,
+  voorkeur_stad: 'Amsterdam',
+  voorkeur_woningtype: 'appartement',
+  voorkeur_aantal_slaapkamers: 2,
+  voorkeur_gemeubileerd: 'gemeubileerd'
+};
+
+const property = {
+  huurprijs: 1500,
+  stad: 'Amsterdam',
+  type: 'appartement',
+  aantal_slaapkamers: 2,
+  gemeubileerd: 'gemeubileerd'
+};
+
+(async () => {
+  const score = await MatchingService.calculateMatchScore(tenant, property);
+  assert.equal(score, 100);
+  console.log('matchingService tests passed');
+})();

--- a/tests/paymentService.test.ts
+++ b/tests/paymentService.test.ts
@@ -1,3 +1,4 @@
+import 'tsconfig-paths/register.js';
 import { strict as assert } from 'node:assert';
 import { paymentService } from '../src/services/PaymentService.ts';
 
@@ -14,3 +15,6 @@ try {
   console.error(err);
   process.exit(1);
 }
+
+// Run matching service tests after payment service tests
+await import('./matchingService.test.ts');


### PR DESCRIPTION
## Summary
- build property matching query when panden table is available
- ensure MatchingService uses relative supabase import
- run tsconfig-paths during tests
- add basic MatchingService test

## Testing
- `npm test` *(fails: Cannot find module '/workspace/huurly_1.0/src/services/payment/PaymentRecordService' imported from /workspace/huurly_1.0/src/services/PaymentService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68599d028c28832bae3aa0fa726a3a10