### PR TITLE
Fix profile picture lookup

### DIFF
--- a/docs/System Architecture and Technical Specifications for Huurly.nl MVP.md
+++ b/docs/System Architecture and Technical Specifications for Huurly.nl MVP.md
@@ -36,7 +36,7 @@ This table will store specific profile information for tenants (Huurders).
 | `roken`                 | `BOOLEAN`            | Geeft aan of de huurder rookt                            |                                                          |
 | `inkomen_verificatie_url` | `TEXT`               | URL naar geüploade inkomensverificatie document          | Opslag in Supabase Storage                               |
 | `referenties`           | `JSONB`              | Referenties van vorige verhuurders                       | Array of objects: {naam, contact, relatie}               |
-| `profiel_foto_url`      | `TEXT`               | URL naar de profielfoto                                  | Opslag in Supabase Storage                               |
+| `profielfoto_url`      | `TEXT`               | URL naar de profielfoto                                  | Opslag in Supabase Storage                               |
 | `profiel_zichtbaar`     | `BOOLEAN`            | Geeft aan of het profiel zichtbaar is voor verhuurders   |                                                          |
 | `profiel_compleet`      | `BOOLEAN`            | Geeft aan of het profiel volledig is ingevuld           | Vereist voor platformtoegang                             |
 | `aangemaakt_op`         | `TIMESTAMP WITH TIME ZONE` | Tijdstempel van aanmaak                                  |                                                          |

--- a/scripts/analyze-tenant-profiles-schema.js
+++ b/scripts/analyze-tenant-profiles-schema.js
@@ -93,7 +93,7 @@ function analyzeColumnUsage(columnNames) {
   // Define columns used in the 7-step modal
   const modalColumns = [
     // Step 1: Personal Information
-    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url',
+    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url',
     
     // Step 2: Family & Relationship
     'marital_status', 'has_children', 'number_of_children', 'children_ages',

--- a/scripts/direct-table-query.js
+++ b/scripts/direct-table-query.js
@@ -74,7 +74,7 @@ function analyzeColumnUsage(actualColumns) {
   // Fields currently used in the 7-step modal
   const modalFields = [
     // Step 1: Personal Information
-    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url',
+    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url',
     
     // Step 2: Family & Relationship
     'marital_status', 'has_children', 'number_of_children', 'children_ages',

--- a/scripts/get-actual-columns.js
+++ b/scripts/get-actual-columns.js
@@ -90,7 +90,7 @@ function analyzeColumns(actualColumns) {
   
   // What the modal currently uses
   const modalFields = [
-    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url',
+    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url',
     'marital_status', 'has_children', 'number_of_children', 'children_ages',
     'profession', 'employer', 'employment_status', 'work_contract_type', 'monthly_income', 'housing_allowance_eligible',
     'has_partner', 'partner_name', 'partner_profession', 'partner_monthly_income', 'partner_employment_status',

--- a/scripts/postgres-schema-analysis.mjs
+++ b/scripts/postgres-schema-analysis.mjs
@@ -110,7 +110,7 @@ async function analyzeUsageVsActual(actualColumns) {
   // Fields currently used in the 7-step modal
   const modalFields = [
     // Step 1: Personal Information
-    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url',
+    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url',
     
     // Step 2: Family & Relationship
     'marital_status', 'has_children', 'number_of_children', 'children_ages',

--- a/scripts/real-schema-analysis.js
+++ b/scripts/real-schema-analysis.js
@@ -120,7 +120,7 @@ function analyzeUsageVsActual(actualColumns) {
   // Define what the modal currently uses
   const modalFields = {
     // Step 1: Personal Information
-    step1: ['first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url'],
+    step1: ['first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url'],
     
     // Step 2: Family & Relationship
     step2: ['marital_status', 'has_children', 'number_of_children', 'children_ages'],

--- a/scripts/schema-analysis-to-file.mjs
+++ b/scripts/schema-analysis-to-file.mjs
@@ -121,7 +121,7 @@ async function analyzeUsageVsActual(actualColumns) {
   // Fields currently used in the 7-step modal
   const modalFields = [
     // Step 1: Personal Information
-    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url',
+    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url',
     
     // Step 2: Family & Relationship
     'marital_status', 'has_children', 'number_of_children', 'children_ages',

--- a/scripts/simple-schema-check.js
+++ b/scripts/simple-schema-check.js
@@ -51,7 +51,7 @@ function analyzeColumns(allColumns) {
   // Columns currently used in the modal
   const usedColumns = [
     'user_id', 'first_name', 'last_name', 'phone', 'date_of_birth', 
-    'nationality', 'sex', 'profile_picture_url',
+    'nationality', 'sex', 'profielfoto_url',
     'marital_status', 'has_children', 'number_of_children', 'children_ages',
     'profession', 'employer', 'employment_status', 'work_contract_type', 
     'monthly_income', 'housing_allowance_eligible',

--- a/scripts/tenant-profiles-schema-analysis.mjs
+++ b/scripts/tenant-profiles-schema-analysis.mjs
@@ -109,7 +109,7 @@ async function analyzeUsageVsActual(actualColumns) {
   // Fields currently used in the 7-step modal
   const modalFields = [
     // Step 1: Personal Information
-    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url',
+    'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url',
     
     // Step 2: Family & Relationship
     'marital_status', 'has_children', 'number_of_children', 'children_ages',

--- a/scripts/test-tenant-profile-creation.js
+++ b/scripts/test-tenant-profile-creation.js
@@ -135,7 +135,7 @@ async function testTenantProfileCreation() {
       pet_details: null,
       smokes: false,
       smoking_details: null,
-      profile_picture_url: null,
+      profielfoto_url: null,
     };
     
     // Try upsert operation

--- a/src/components/admin/DatabaseCleanupRecommendations.tsx
+++ b/src/components/admin/DatabaseCleanupRecommendations.tsx
@@ -46,7 +46,7 @@ const DatabaseCleanupRecommendations: React.FC<CleanupRecommendationsProps> = ({
 
     // Specific recommendations based on known modal usage
     const modalUsedFields = [
-      'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profile_picture_url',
+      'first_name', 'last_name', 'phone', 'date_of_birth', 'nationality', 'sex', 'profielfoto_url',
       'marital_status', 'has_children', 'number_of_children', 'children_ages',
       'profession', 'employer', 'employment_status', 'work_contract_type', 'monthly_income', 'housing_allowance_eligible',
       'has_partner', 'partner_name', 'partner_profession', 'partner_monthly_income', 'partner_employment_status',

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -318,7 +318,6 @@ export type Database = {
           max_kamers: number | null
           min_kamers: number | null
           partner: boolean | null
-          profiel_foto_url: string | null
           profielfoto_url: string | null
           roken: boolean | null
           voorkeur_verhuisdatum: string | null
@@ -350,7 +349,6 @@ export type Database = {
           max_kamers?: number | null
           min_kamers?: number | null
           partner?: boolean | null
-          profiel_foto_url?: string | null
           profielfoto_url?: string | null
           roken?: boolean | null
           voorkeur_verhuisdatum?: string | null
@@ -382,7 +380,6 @@ export type Database = {
           max_kamers?: number | null
           min_kamers?: number | null
           partner?: boolean | null
-          profiel_foto_url?: string | null
           profielfoto_url?: string | null
           roken?: boolean | null
           voorkeur_verhuisdatum?: string | null

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -318,7 +318,6 @@ export type Database = {
           max_kamers: number | null
           min_kamers: number | null
           partner: boolean | null
-          profiel_foto_url: string | null
           profielfoto_url: string | null
           roken: boolean | null
           voorkeur_verhuisdatum: string | null
@@ -350,7 +349,6 @@ export type Database = {
           max_kamers?: number | null
           min_kamers?: number | null
           partner?: boolean | null
-          profiel_foto_url?: string | null
           profielfoto_url?: string | null
           roken?: boolean | null
           voorkeur_verhuisdatum?: string | null
@@ -382,7 +380,6 @@ export type Database = {
           max_kamers?: number | null
           min_kamers?: number | null
           partner?: boolean | null
-          profiel_foto_url?: string | null
           profielfoto_url?: string | null
           roken?: boolean | null
           voorkeur_verhuisdatum?: string | null

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -346,7 +346,7 @@ export class UserService extends DatabaseService {
           furnished_preference: sanitizeFurnishedPreference(sanitizedData.furnishedPreference),
           desired_amenities: sanitizedData.desiredAmenities || [],
           smoking_details: sanitizedData.smokingDetails || null,
-          profile_picture_url: sanitizedData.profilePictureUrl || null,
+          profielfoto_url: sanitizedData.profilePictureUrl || null,
           
           // Priority 1: Guarantor Information
           guarantor_available: sanitizedData.guarantorAvailable || false,
@@ -619,13 +619,13 @@ export class UserService extends DatabaseService {
    */
   async getProfilePictureUrl(userId: string): Promise<string | null> {
     try {
-      const { data: profile } = await supabase
-        .from('gebruikers')
-        .select('profile_picture_url')
-        .eq('id', userId)
+      const { data: tenant } = await supabase
+        .from('huurders')
+        .select('profielfoto_url')
+        .eq('user_id', userId)
         .single();
-      
-      return profile?.profile_picture_url || null;
+
+      return tenant?.profielfoto_url || null;
     } catch (error) {
       logger.error('Error fetching profile picture URL:', error);
       return null;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -71,7 +71,7 @@ export interface Database {
           max_huur: number | null
           gewenste_startdatum: string | null
           motivatie: string | null
-          profiel_foto_url: string | null
+          profielfoto_url: string | null
           verificatie_status: string
           created_at: string
           updated_at: string
@@ -91,7 +91,7 @@ export interface Database {
           max_huur?: number | null
           gewenste_startdatum?: string | null
           motivatie?: string | null
-          profiel_foto_url?: string | null
+          profielfoto_url?: string | null
           verificatie_status?: string
           created_at?: string
           updated_at?: string
@@ -110,7 +110,7 @@ export interface Database {
           max_huur?: number | null
           gewenste_startdatum?: string | null
           motivatie?: string | null
-          profiel_foto_url?: string | null
+          profielfoto_url?: string | null
           verificatie_status?: string
           updated_at?: string
         }


### PR DESCRIPTION
## Summary
- fetch tenant profile pictures from `huurders.profielfoto_url`
- align admin recommendations with new column name
- replace outdated field name across schema scripts
- drop `profiel_foto_url` from generated types

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3fd0b078832b8b328e15bc2d3062