### PR TITLE
Add autocomplete attribute to signup password fields

### DIFF
--- a/src/components/auth/MultiStepSignupModal.tsx
+++ b/src/components/auth/MultiStepSignupModal.tsx
@@ -153,6 +153,7 @@ export const MultiStepSignupModal = ({ isOpen, onClose }: MultiStepSignupModalPr
                   type="password"
                   value={formData.password}
                   onChange={(e) => updateFormData('password', e.target.value)}
+                  autoComplete="new-password"
                   required
                 />
               </div>
@@ -163,6 +164,7 @@ export const MultiStepSignupModal = ({ isOpen, onClose }: MultiStepSignupModalPr
                   type="password"
                   value={formData.confirmPassword}
                   onChange={(e) => updateFormData('confirmPassword', e.target.value)}
+                  autoComplete="new-password"
                   required
                 />
               </div>


### PR DESCRIPTION
## Summary
- enhance password inputs with `autoComplete="new-password"` in the multi-step signup modal

## Testing
- `npm test` *(fails: Cannot find module '/workspace/huurly_1.0/src/services/payment/PaymentRecordService')*


------
https://chatgpt.com/codex/tasks/task_e_685c693538ac832bb1c8104805f7df01