### PR TITLE
Fix Node ESM imports

### DIFF
--- a/src/lib/auth/roleMapper.ts
+++ b/src/lib/auth/roleMapper.ts
@@ -1,6 +1,6 @@
 
-import { UserRole } from '@/types';
-import { logger } from '@/lib/logger';
+import { UserRole } from '../../types/index.ts';
+import { logger } from '../logger.ts';
 
 class RoleMapper {
   /**

--- a/src/lib/auth/userMapper.ts
+++ b/src/lib/auth/userMapper.ts
@@ -1,9 +1,9 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '../../integrations/supabase/client.ts';
 import { User } from '@/types';
 import { User as SupabaseUser } from '@supabase/supabase-js';
-import { logger } from '@/lib/logger';
-import { roleMapper } from './roleMapper';
+import { logger } from '../../lib/logger.ts';
+import { roleMapper } from './roleMapper.ts';
 
 class UserMapper {
   /**

--- a/src/services/MatchingService.ts
+++ b/src/services/MatchingService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '../integrations/supabase/client';
+import { supabase } from '../integrations/supabase/client.ts';
 
 export class MatchingService {
   static async getMatches(tenantId: string) {

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -1,9 +1,9 @@
 
-import { paymentRecordService, PaymentRecord, PaymentRecordInsert } from './payment/PaymentRecordService';
-import { stripeCheckoutService } from './payment/StripeCheckoutService';
-import { subscriptionService, SubscriptionStatus } from './payment/SubscriptionService';
-import { paymentWebhookService } from './payment/PaymentWebhookService';
-import { pricingService } from './payment/PricingService';
+import { paymentRecordService, PaymentRecord, PaymentRecordInsert } from './payment/PaymentRecordService.ts';
+import { stripeCheckoutService } from './payment/StripeCheckoutService.ts';
+import { subscriptionService, SubscriptionStatus } from './payment/SubscriptionService.ts';
+import { paymentWebhookService } from './payment/PaymentWebhookService.ts';
+import { pricingService } from './payment/PricingService.ts';
 import { DatabaseResponse } from '../lib/database';
 
 export class PaymentService {

--- a/src/services/payment/PaymentRecordService.ts
+++ b/src/services/payment/PaymentRecordService.ts
@@ -1,9 +1,9 @@
 
-import { supabase } from '../../integrations/supabase/client';
-import { DatabaseService, DatabaseResponse } from '../../lib/database';
-import { ErrorHandler } from '../../lib/errors';
-import { Tables, TablesInsert } from '../../integrations/supabase/types';
-import { logger } from '../../lib/logger';
+import { supabase } from '../../integrations/supabase/client.ts';
+import { DatabaseService, DatabaseResponse } from '../../lib/database.ts';
+import { ErrorHandler } from '../../lib/errors.ts';
+import { Tables, TablesInsert } from '../../integrations/supabase/types.ts';
+import { logger } from '../../lib/logger.ts';
 
 export type PaymentRecord = Tables<'betalingen'>;
 export type PaymentRecordInsert = TablesInsert<'betalingen'>;

--- a/src/services/payment/PaymentWebhookService.ts
+++ b/src/services/payment/PaymentWebhookService.ts
@@ -1,8 +1,8 @@
 
-import { supabase } from '../../integrations/supabase/client';
-import { DatabaseService, DatabaseResponse } from '../../lib/database';
-import { ErrorHandler } from '../../lib/errors';
-import { PaymentRecord } from './PaymentRecordService';
+import { supabase } from '../../integrations/supabase/client.ts';
+import { DatabaseService, DatabaseResponse } from '../../lib/database.ts';
+import { ErrorHandler } from '../../lib/errors.ts';
+import { PaymentRecord } from './PaymentRecordService.ts';
 
 export class PaymentWebhookService extends DatabaseService {
   async handlePaymentSuccess(sessionId: string): Promise<DatabaseResponse<PaymentRecord>> {

--- a/src/services/payment/PricingService.ts
+++ b/src/services/payment/PricingService.ts
@@ -1,8 +1,8 @@
 
-import { SUBSCRIPTION_PLANS, formatPrice } from '../../lib/stripe';
-import { DatabaseService, DatabaseResponse } from '../../lib/database';
-import { ErrorHandler } from '../../lib/errors';
-import { logger } from '../../lib/logger';
+import { SUBSCRIPTION_PLANS, formatPrice } from '../../lib/stripe.ts';
+import { DatabaseService, DatabaseResponse } from '../../lib/database.ts';
+import { ErrorHandler } from '../../lib/errors.ts';
+import { logger } from '../../lib/logger.ts';
 
 export class PricingService extends DatabaseService {
   getPricingInfo(role: 'huurder' | 'verhuurder') {

--- a/src/services/payment/StripeCheckoutService.ts
+++ b/src/services/payment/StripeCheckoutService.ts
@@ -1,10 +1,10 @@
 
-import { supabase } from '../../integrations/supabase/client';
-import { getStripe, SUBSCRIPTION_PLANS } from '../../lib/stripe';
-import { DatabaseService, DatabaseResponse } from '../../lib/database';
-import { ErrorHandler } from '../../lib/errors';
-import { paymentRecordService } from './PaymentRecordService';
-import { logger } from '../../lib/logger';
+import { supabase } from '../../integrations/supabase/client.ts';
+import { getStripe, SUBSCRIPTION_PLANS } from '../../lib/stripe.ts';
+import { DatabaseService, DatabaseResponse } from '../../lib/database.ts';
+import { ErrorHandler } from '../../lib/errors.ts';
+import { paymentRecordService } from './PaymentRecordService.ts';
+import { logger } from '../../lib/logger.ts';
 
 export class StripeCheckoutService extends DatabaseService {
   async createCheckoutSession(userId: string): Promise<DatabaseResponse<{ url: string }>> {

--- a/src/services/payment/SubscriptionService.ts
+++ b/src/services/payment/SubscriptionService.ts
@@ -1,8 +1,8 @@
 
-import { supabase } from '../../integrations/supabase/client';
-import { DatabaseService, DatabaseResponse } from '../../lib/database';
-import { ErrorHandler } from '../../lib/errors';
-import { PaymentRecord } from './PaymentRecordService';
+import { supabase } from '../../integrations/supabase/client.ts';
+import { DatabaseService, DatabaseResponse } from '../../lib/database.ts';
+import { ErrorHandler } from '../../lib/errors.ts';
+import { PaymentRecord } from './PaymentRecordService.ts';
 
 export interface SubscriptionStatus {
   hasActiveSubscription: boolean;


### PR DESCRIPTION
## Summary
- add `.ts` extensions to Node imports so that ts-node/esm can resolve them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cf85077c4832bbf8f722cfa91ac01