### PR TITLE
Add storage policies and helper functions

### DIFF
--- a/src/lib/storageAccess.ts
+++ b/src/lib/storageAccess.ts
@@ -1,0 +1,112 @@
+import { supabase } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
+
+/**
+ * Check if the currently authenticated user may view the documents of `userId`.
+ * A user can always view their own documents. Reviewers and admins can view
+ * documents of other users based on the `gebruiker_rollen` table.
+ */
+export async function canViewDocument(userId: string): Promise<boolean> {
+  try {
+    const {
+      data: { user: currentUser },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !currentUser) {
+      return false;
+    }
+
+    if (currentUser.id === userId) {
+      return true;
+    }
+
+    const { data, error } = await supabase
+      .from('gebruiker_rollen')
+      .select('role')
+      .eq('user_id', currentUser.id)
+      .in('role', ['reviewer', 'admin']);
+
+    if (error) {
+      logger.error('Role check error:', error);
+      return false;
+    }
+
+    return (data ?? []).length > 0;
+  } catch (err) {
+    logger.error('canViewDocument error:', err);
+    return false;
+  }
+}
+
+/**
+ * Return a signed URL for a document if the viewer has access. The viewer is
+ * determined via `supabase.auth`. The owner id is extracted from the file path.
+ */
+export async function getDocumentUrl(
+  filePath: string,
+): Promise<string | null> {
+  const ownerId = filePath.split('/')[0];
+  const allowed = await canViewDocument(ownerId);
+  if (!allowed) {
+    return null;
+  }
+
+  const { data, error } = await supabase.storage
+    .from('documents')
+    .createSignedUrl(filePath, 60 * 60);
+  if (error) {
+    logger.error('Signed URL error:', error);
+    return null;
+  }
+  return data.signedUrl;
+}
+
+/**
+ * Upload a document for the authenticated user. The file will be stored under
+ * `${authUser.id}/filename.ext` in the `documents` bucket.
+ */
+export async function uploadDocument(file: File): Promise<string | null> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return null;
+  }
+  const filePath = `${user.id}/${file.name}`;
+  const { error } = await supabase.storage
+    .from('documents')
+    .upload(filePath, file);
+  if (error) {
+    logger.error('Document upload error:', error);
+    return null;
+  }
+  return filePath;
+}
+
+/**
+ * Upload or replace the current user's profile picture. The picture is stored
+ * as `${authUser.id}/profile.jpg` in the `profile-pictures` bucket.
+ */
+export async function uploadProfilePicture(file: File): Promise<string | null> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return null;
+  }
+  const filePath = `${user.id}/profile.jpg`;
+  const { error } = await supabase.storage
+    .from('profile-pictures')
+    .upload(filePath, file, {
+      upsert: true,
+      contentType: file.type,
+    });
+  if (error) {
+    logger.error('Profile picture upload error:', error);
+    return null;
+  }
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from('profile-pictures').getPublicUrl(filePath);
+  return publicUrl;
+}

--- a/supabase/migrations/20250626000000_create_storage_policies.sql
+++ b/supabase/migrations/20250626000000_create_storage_policies.sql
@@ -1,0 +1,50 @@
+-- Create helper function to get first path segment
+CREATE OR REPLACE FUNCTION public.filename_prefix(name text)
+RETURNS text
+LANGUAGE sql IMMUTABLE STRICT
+AS $$
+  SELECT split_part(name, '/', 1);
+$$;
+
+-- Ensure RLS is enabled on storage.objects
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- Policy for inserting into documents bucket
+CREATE POLICY "Allow users to upload own documents" ON storage.objects
+FOR INSERT
+WITH CHECK (
+  bucket_id = 'documents' AND public.filename_prefix(name) = auth.uid()
+);
+
+-- Policy for deleting from documents bucket
+CREATE POLICY "Allow users to delete own documents" ON storage.objects
+FOR DELETE
+USING (
+  bucket_id = 'documents' AND public.filename_prefix(name) = auth.uid()
+);
+
+-- Policy for selecting documents
+CREATE POLICY "Allow users or reviewers/admin to read documents" ON storage.objects
+FOR SELECT
+USING (
+  bucket_id = 'documents' AND (
+    public.filename_prefix(name) = auth.uid() OR EXISTS (
+      SELECT 1 FROM public.gebruiker_rollen gr
+      WHERE gr.user_id = auth.uid() AND gr.role IN ('reviewer', 'admin')
+    )
+  )
+);
+
+-- Policy for inserting into profile-pictures bucket
+CREATE POLICY "Allow users to upload own profile pictures" ON storage.objects
+FOR INSERT
+WITH CHECK (
+  bucket_id = 'profile-pictures' AND public.filename_prefix(name) = auth.uid()
+);
+
+-- Policy for deleting from profile-pictures bucket
+CREATE POLICY "Allow users to delete own profile pictures" ON storage.objects
+FOR DELETE
+USING (
+  bucket_id = 'profile-pictures' AND public.filename_prefix(name) = auth.uid()
+);


### PR DESCRIPTION
## Summary
- add helper function and RLS policies for storage buckets
- provide TypeScript helpers for document access and uploads

## Testing
- `npm test` *(fails: Cannot find module '/workspace/huurly_1.0/src/services/payment/PaymentRecordService')*
- `npm run lint` *(fails: 218 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685d00c06b64832b9ab47b2ea240cf2d