### PR TITLE
Fix tenant queries using correct id column

### DIFF
--- a/src/services/DashboardDataService.ts
+++ b/src/services/DashboardDataService.ts
@@ -75,7 +75,7 @@ export class DashboardDataService {
       const { data, error } = await supabase
         .from('huurders')
         .select('*')
-        .eq('huurder_id', userId)
+        .eq('id', userId)
         .single();
 
       if (error) {

--- a/src/services/DashboardService.ts
+++ b/src/services/DashboardService.ts
@@ -50,7 +50,7 @@ export class DashboardService {
       const { data: tenantProfile, error: profileError } = await supabase
         .from('huurders')
         .select('profiel_weergaven')
-        .eq('user_id', userId)
+        .eq('id', userId)
         .maybeSingle();
 
       if (profileError && profileError.code !== 'PGRST116') {

--- a/src/services/MatchingService.ts
+++ b/src/services/MatchingService.ts
@@ -8,7 +8,7 @@ export class MatchingService {
       const { data: tenant, error: tenantError } = await supabase
         .from('huurders')
         .select('*')
-        .eq('gebruiker_id', tenantId)
+        .eq('id', tenantId)
         .single();
 
       if (tenantError) throw tenantError;
@@ -149,7 +149,7 @@ export class MatchingService {
           voorkeur_gemeubileerd: preferences.furnished,
           bijgewerkt_op: new Date().toISOString()
         })
-        .eq('gebruiker_id', tenantId);
+        .eq('id', tenantId);
 
       if (error) throw error;
     } catch (error) {

--- a/src/services/SearchService.ts
+++ b/src/services/SearchService.ts
@@ -115,7 +115,7 @@ export class SearchService {
       // Start building the query
       let dbQuery = supabase
         .from('huurders')
-        .select('*, user:user_id(*)', { count: 'exact' }) as any;
+        .select('*, user:gebruikers(*)', { count: 'exact' }) as any;
       
       // Apply text search if query is provided
       if (query && query.trim() !== '') {

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -296,14 +296,14 @@ export class UserService extends DatabaseService {
         const { data: existingProfile } = await supabase
           .from('huurders')
           .select('id')
-          .eq('user_id', currentUserId)
+          .eq('id', currentUserId)
           .maybeSingle();
 
         logger.info("Existing tenant profile check:", existingProfile);
 
         // 3. Prepare tenant profile data
         const tenantProfileData: any = {
-          user_id: currentUserId,
+          id: currentUserId,
           first_name: sanitizedData.firstName,
           last_name: sanitizedData.lastName,
           phone: sanitizedData.phone,
@@ -373,7 +373,7 @@ export class UserService extends DatabaseService {
           const { data, error: tenantError } = await supabase
             .from('huurders')
             .update(tenantProfileData)
-            .eq('user_id', currentUserId)
+            .eq('id', currentUserId)
             .select()
             .single();
 
@@ -418,7 +418,7 @@ export class UserService extends DatabaseService {
       const { data, error } = await supabase
         .from('huurders')
         .select('*')
-        .eq('user_id', userId)
+        .eq('id', userId)
         .maybeSingle();
 
       return { data, error };
@@ -508,7 +508,7 @@ export class UserService extends DatabaseService {
       }
 
       // Get user IDs from tenant profiles
-      const userIds = tenantData.map(tenant => tenant.user_id);
+      const userIds = tenantData.map(tenant => tenant.id);
 
       // Get corresponding profiles
       const { data: profilesData, error: profilesError } = await supabase
@@ -523,7 +523,7 @@ export class UserService extends DatabaseService {
 
       // Manual join - combine tenant profiles with their corresponding profiles
       const joinedData = tenantData.map(tenant => {
-        const profile = profilesData?.find(p => p.id === tenant.user_id);
+        const profile = profilesData?.find(p => p.id === tenant.id);
         return {
           ...tenant,
           profiles: profile
@@ -607,7 +607,7 @@ export class UserService extends DatabaseService {
       const { data, error } = await supabase
         .from('gebruiker_rollen')
         .select('*')
-        .eq('user_id', userId)
+        .eq('id', userId)
         .single();
 
       return { data, error };


### PR DESCRIPTION
## Summary
- fix queries to use `id` instead of non‑existent `user_id`
- update joins in search service
- fix matching service references

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d175f8750832b9554be84589b46cb