### PR TITLE
Align Supabase document field names

### DIFF
--- a/src/services/DashboardDataService.ts
+++ b/src/services/DashboardDataService.ts
@@ -157,9 +157,8 @@ export class DashboardDataService extends DatabaseService {
         .from('documenten')
         .update({
           status,
-          beoordeeld_door: currentUserId,
-          beoordeeld_op: new Date().toISOString(),
-          opmerkingen: notes || null,
+          beoordelaar_id: currentUserId,
+          beoordeling_notitie: notes || null,
           bijgewerkt_op: new Date().toISOString(),
         })
         .eq('id', documentId)

--- a/src/services/DocumentService.ts
+++ b/src/services/DocumentService.ts
@@ -12,11 +12,10 @@ export interface Document {
   huurder_id: string;
   type: DocumentType;
   bestand_url: string;
-  bestand_naam: string;
+  bestandsnaam: string;
   status: DocumentStatus;
-  beoordeeld_door?: string;
-  beoordeeld_op?: string;
-  opmerkingen?: string;
+  beoordelaar_id?: string;
+  beoordeling_notitie?: string | null;
   aangemaakt_op: string;
   bijgewerkt_op: string;
 }
@@ -53,7 +52,7 @@ export class DocumentService extends DatabaseService {
           huurder_id: userId,
           type: documentType,
           bestand_url: uploadData.path,
-          bestand_naam: file.name,
+          bestandsnaam: file.name,
           status: 'wachtend',
           aangemaakt_op: new Date().toISOString(),
           bijgewerkt_op: new Date().toISOString(),
@@ -137,9 +136,8 @@ export class DocumentService extends DatabaseService {
         .from('documenten')
         .update({
           status,
-          beoordeeld_door: currentUserId,
-          beoordeeld_op: new Date().toISOString(),
-          opmerkingen: notes || null,
+          beoordelaar_id: currentUserId,
+          beoordeling_notitie: notes || null,
           bijgewerkt_op: new Date().toISOString(),
         })
         .eq('id', documentId)

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -122,13 +122,17 @@ export const getDocumentsForReview = async () => {
 // Update document status
 export const updateDocumentStatus = async (documentId: string, status: 'goedgekeurd' | 'afgekeurd', notes?: string) => {
   try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
     const { data, error } = await supabase
       .from('documenten')
       .update({
         status,
-        beoordeeld_op: new Date().toISOString(),
-        opmerkingen: notes || null,
-        bijgewerkt_op: new Date().toISOString()
+        beoordelaar_id: user?.id || null,
+        beoordeling_notitie: notes || null,
+        bijgewerkt_op: new Date().toISOString(),
       })
       .eq('id', documentId)
       .select()


### PR DESCRIPTION
## Summary
- update `DocumentService` interface and queries to match actual Supabase field names
- fix `DashboardDataService.updateDocumentStatus` for renamed columns
- adjust utility query for document status update

## Testing
- `npm run lint` *(fails: 193 errors, 25 warnings)*
- `npm run generate-types` *(fails: access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_685d57c7f978832b9db7400ca72f80fb