### PR TITLE
Fix admin and reviewer dashboard hooks

### DIFF
--- a/src/hooks/useBeheerderDashboard.ts
+++ b/src/hooks/useBeheerderDashboard.ts
@@ -1,6 +1,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
-import { DashboardDataService } from '@/services/DashboardDataService';
+import { dashboardService } from '@/services/DashboardService';
+import { userService } from '@/services/UserService';
 import { AdminStats, User } from '@/types';
 
 export const useBeheerderDashboard = () => {
@@ -17,8 +18,8 @@ export const useBeheerderDashboard = () => {
     setLoading(true);
     try {
       const [statsResponse, usersResponse] = await Promise.all([
-        DashboardDataService.getAdminStats(),
-        DashboardDataService.getAllUsers(),
+        dashboardService.getAdminStats(),
+        userService.getUsers(),
       ]);
       
       if (statsResponse.success && statsResponse.data) {

--- a/src/hooks/useBeoordelaarDashboard.ts
+++ b/src/hooks/useBeoordelaarDashboard.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAuthStore } from '@/store/authStore';
-import { DashboardDataService } from '@/services/DashboardDataService';
+import { documentService } from '@/services/DocumentService';
 import { Document } from '@/types'; // Assuming a Document type exists
 import { logger } from '@/utils/logger';
 
@@ -13,8 +13,7 @@ export const useBeoordelaarDashboard = () => {
     if (!user) return;
     setLoading(true);
     try {
-      // This service method needs to be created
-      const response = await DashboardDataService.getReviewQueue();
+      const response = await documentService.getDocumentsForReview();
       if (response.success) {
         setDocuments(response.data || []);
       } else {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -619,6 +619,47 @@ export type Database = {
           },
         ]
       }
+      audit_logs: {
+        Row: {
+          id: string
+          user_id: string | null
+          action: string | null
+          table_name: string | null
+          record_id: string | null
+          old_values: Json | null
+          new_values: Json | null
+          aangemaakt_op: string | null
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          action?: string | null
+          table_name?: string | null
+          record_id?: string | null
+          old_values?: Json | null
+          new_values?: Json | null
+          aangemaakt_op?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          action?: string | null
+          table_name?: string | null
+          record_id?: string | null
+          old_values?: Json | null
+          new_values?: Json | null
+          aangemaakt_op?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "audit_logs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "gebruikers"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
     }
     Views: {
       actieve_huurders: {


### PR DESCRIPTION
## Summary
- correct imports in admin and reviewer dashboard hooks
- query user list and stats from existing services
- add `audit_logs` table definition to database types

## Testing
- `npm run lint` *(fails: 193 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685d57c8c1e8832b8242328e9a1ba310