### PR TITLE
Fix document service usages

### DIFF
--- a/src/components/modals/DocumentReviewModal.tsx
+++ b/src/components/modals/DocumentReviewModal.tsx
@@ -48,7 +48,7 @@ const DocumentReviewModal = ({
     setIsSubmitting(true);
 
     try {
-      const result = await documentService.approveDocument(document.id);
+      const result = await documentService.reviewDocument(document.id, 'goedgekeurd', reviewNotes);
       if (result.success) {
         onApprove(document.id, reviewNotes);
         onOpenChange(false);
@@ -90,7 +90,7 @@ const DocumentReviewModal = ({
     setIsSubmitting(true);
 
     try {
-      const result = await documentService.rejectDocument(document.id, rejectionReason);
+      const result = await documentService.reviewDocument(document.id, 'afgekeurd', rejectionReason);
       if (result.success) {
         onReject(document.id, rejectionReason);
         onOpenChange(false);

--- a/src/components/modals/DocumentUploadModal.tsx
+++ b/src/components/modals/DocumentUploadModal.tsx
@@ -53,7 +53,7 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
     if (!user?.id) return;
     
     try {
-      const result = await documentService.getUserDocuments(user.id);
+      const result = await documentService.getDocuments(user.id);
       if (result.success && result.data) {
         setExistingDocuments(result.data);
       }
@@ -243,7 +243,7 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
     ));
 
     try {
-      const result = await documentService.uploadDocument(document.file, document.type);
+      const result = await documentService.uploadDocument(document.file, document.type, user.id);
       
       if (result.success && result.data) {
         setDocuments(prev => prev.map(d => 

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { storageService } from '@/lib/storage';
 import { documentService, DocumentType } from '@/services/DocumentService';
+import { useAuthStore } from '@/store/authStore';
 import { cn } from '@/lib/utils';
 import { FileUploadDropZone } from './file-upload/FileUploadDropZone';
 import { FileUploadProgress, UploadingFile } from './file-upload/FileUploadProgress';
@@ -31,6 +32,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
 }) => {
   const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
   const { toast } = useToast();
+  const { user } = useAuthStore();
 
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     if (disabled) return;
@@ -65,7 +67,10 @@ export const FileUpload: React.FC<FileUploadProps> = ({
           index === i ? { ...uf, progress: 10 } : uf
         ));
 
-        const result = await documentService.uploadDocument(file, documentType);
+        if (!user?.id) {
+          throw new Error('Geen gebruiker ingelogd');
+        }
+        const result = await documentService.uploadDocument(file, documentType, user.id);
 
         if (!result.success) {
           throw result.error || new Error('Upload mislukt');

--- a/src/hooks/useBeoordelaarActions.ts
+++ b/src/hooks/useBeoordelaarActions.ts
@@ -2,7 +2,6 @@
 import { useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { documentService } from '@/services/DocumentService';
-import { dashboardDataService } from '@/services/DashboardDataService';
 import { useAuthStore } from '@/store/authStore';
 
 export const useBeoordelaarActions = () => {
@@ -13,7 +12,7 @@ export const useBeoordelaarActions = () => {
   const approveDocument = async (documentId: string) => {
     setIsReviewing(true);
     try {
-      const result = await documentService.approveDocument(documentId);
+      const result = await documentService.reviewDocument(documentId, 'goedgekeurd');
       if (result.success) {
         toast({
           title: 'Document goedgekeurd',
@@ -38,9 +37,7 @@ export const useBeoordelaarActions = () => {
   const rejectDocument = async (documentId: string, reason: string) => {
     setIsReviewing(true);
     try {
-      // Map English status to Dutch status for the service call
-      const dutchStatus = 'afgewezen' as const;
-      const result = await dashboardDataService.reviewDocument(documentId, dutchStatus, reason);
+      const result = await documentService.reviewDocument(documentId, 'afgekeurd', reason);
       if (result.success) {
         toast({
           title: 'Document afgewezen',

--- a/src/hooks/useHuurder.ts
+++ b/src/hooks/useHuurder.ts
@@ -4,6 +4,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuthStore } from '@/store/authStore';
 import { dashboardDataService } from '@/services/DashboardDataService';
 import { userService } from '@/services/UserService';
+import { documentService } from '@/services/DocumentService';
 import { Document, TenantProfile, Subscription, TenantDashboardData, User } from '@/types';
 
 export const useHuurder = () => {
@@ -31,7 +32,7 @@ export const useHuurder = () => {
     try {
       const [statsResponse, docsResponse, profileResponse, subResponse, pictureUrl] = await Promise.all([
         dashboardDataService.getTenantDashboardStats(user.id),
-        dashboardDataService.getUserDocuments(user.id),
+        documentService.getDocuments(user.id),
         userService.getTenantProfile(user.id),
         dashboardDataService.getSubscription(user.id),
         userService.getProfilePictureUrl(user.id),

--- a/src/services/DocumentService.ts
+++ b/src/services/DocumentService.ts
@@ -12,7 +12,7 @@ export interface Document {
   huurder_id: string;
   type: DocumentType;
   bestand_url: string;
-  bestand_naam: string;
+  bestandsnaam: string;
   status: DocumentStatus;
   beoordeeld_door?: string;
   beoordeeld_op?: string;
@@ -44,7 +44,7 @@ export class DocumentService extends DatabaseService {
         .upload(fileName, file);
 
       if (uploadError) {
-        throw ErrorHandler.handleStorageError(uploadError);
+        throw ErrorHandler.createFileUploadError(uploadError.message);
       }
 
       const { data: document, error: dbError } = await supabase
@@ -53,7 +53,7 @@ export class DocumentService extends DatabaseService {
           huurder_id: userId,
           type: documentType,
           bestand_url: uploadData.path,
-          bestand_naam: file.name,
+          bestandsnaam: file.name,
           status: 'wachtend',
           aangemaakt_op: new Date().toISOString(),
           bijgewerkt_op: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- adjust DocumentService to use `bestandsnaam` and replace removed handleStorageError
- switch components and hooks to new methods `reviewDocument` and `getDocuments`
- pass `userId` to `uploadDocument`

## Testing
- `npm run lint` *(fails: 193 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d57c8ee20832b8dab7a299cb74d12