### PR TITLE
Load Stripe config from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Copy `.env.example` to `.env` in the project root and provide your own values fo
 VITE_SUPABASE_URL=<your-supabase-url>
 VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 VITE_STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
+VITE_STRIPE_HUURDER_PRICE_ID=<your-huurder-price-id>
 STRIPE_SECRET_KEY=<your-secret-key>
 STRIPE_WEBHOOK_SECRET=<your-webhook-secret>
 SUPABASE_URL=<your-supabase-url>
@@ -96,6 +97,7 @@ Create a `.env` file in the project root with your keys:
 
 ```env
 VITE_STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
+VITE_STRIPE_HUURDER_PRICE_ID=<your-huurder-price-id>
 STRIPE_SECRET_KEY=<your-secret-key>
 STRIPE_WEBHOOK_SECRET=<your-webhook-secret>
 SUPABASE_URL=<your-supabase-url>

--- a/src/lib/stripe-config.ts
+++ b/src/lib/stripe-config.ts
@@ -5,13 +5,12 @@
 
 import { loadStripe, Stripe } from '@stripe/stripe-js';
 import { logger } from './logger';
+import { getEnvVar } from './env';
 
-// Stripe configuration - using your provided sandbox keys
+// Stripe configuration loaded from environment variables
 export const STRIPE_CONFIG = {
-  // Your provided publishable key
-  publishableKey: 'pk_test_51ReDL9FWpC3XRbUY3IgFVMmMUMVGZ07rt5KRf3Gk4DDluKP6jxwxrKULJo4UzzWHVgtbR4IikwBjWZyZdMLK67CK00m3bS21gl',
-  // Your actual price ID for €65/year
-  huurderPriceId: 'price_1ReDObFWpC3XRbUYyUbOr5Na',
+  publishableKey: getEnvVar('VITE_STRIPE_PUBLISHABLE_KEY') || '',
+  huurderPriceId: getEnvVar('VITE_STRIPE_HUURDER_PRICE_ID') || '',
 };
 
 // Validate configuration


### PR DESCRIPTION
## Summary
- pull Stripe publishable key and plan price ID from environment variables
- document new env var `VITE_STRIPE_HUURDER_PRICE_ID`

## Testing
- `npm run lint` *(fails: 219 problems)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685d6f896500832b9cec5f04c02612b9