### PR TITLE
Use env vars for Supabase client

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ SUPABASE_URL=<your-supabase-url>
 SUPABASE_ANON_KEY=<your-supabase-anon-key>
 SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
 ```
+`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` initialize the frontend Supabase client in `src/integrations/supabase/client.ts`.
 The `SUPABASE_SERVICE_ROLE_KEY` is required for server-side scripts and edge
 functions, including the new `register-user` function that provisions user
 profiles after sign up.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://sqhultitvpivlnlgogen.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNxaHVsdGl0dnBpdmxubGdvZ2VuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxMDgxNTIsImV4cCI6MjA2NTY4NDE1Mn0.ZPfzoKgcMrzcKA5klMaef9jZSb258IlwKUBz244oJ3E";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- read Supabase credentials from `import.meta.env` in the client
- document Supabase client environment variables in README

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d6f9af5a8832ba846bcdc3f51336a