### PR TITLE
Remove VITE prefix from env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,14 @@
 # Supabase configuration
-VITE_SUPABASE_URL=
-VITE_SUPABASE_ANON_KEY=
-
-# Stripe configuration
-VITE_STRIPE_PUBLISHABLE_KEY=
-STRIPE_SECRET_KEY=
-STRIPE_WEBHOOK_SECRET=
-VITE_STRIPE_HUURDER_PRICE_ID=
-
-# Server-side Supabase credentials
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
+
+# Stripe configuration
+STRIPE_PUBLISHABLE_KEY=
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_HUURDER_PRICE_ID=
+
+# Server-side Supabase credentials
 # Used by server-side scripts and edge functions like register-user
 SUPABASE_SERVICE_ROLE_KEY=
 

--- a/README.md
+++ b/README.md
@@ -62,17 +62,15 @@ The application relies on all environment variables defined in `.env.example`. I
 Copy `.env.example` to `.env` in the project root and provide your own values for the following keys:
 
 ```env
-VITE_SUPABASE_URL=<your-supabase-url>
-VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
-VITE_STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
-VITE_STRIPE_HUURDER_PRICE_ID=<your-huurder-price-id>
-STRIPE_SECRET_KEY=<your-secret-key>
-STRIPE_WEBHOOK_SECRET=<your-webhook-secret>
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_ANON_KEY=<your-supabase-anon-key>
+STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
+STRIPE_HUURDER_PRICE_ID=<your-huurder-price-id>
+STRIPE_SECRET_KEY=<your-secret-key>
+STRIPE_WEBHOOK_SECRET=<your-webhook-secret>
 SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
 ```
-`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` initialize the frontend Supabase client in `src/integrations/supabase/client.ts`.
+`SUPABASE_URL` and `SUPABASE_ANON_KEY` initialize the frontend Supabase client in `src/integrations/supabase/client.ts`.
 The `SUPABASE_SERVICE_ROLE_KEY` is required for server-side scripts and edge
 functions, including the new `register-user` function that provisions user
 profiles after sign up.
@@ -97,8 +95,8 @@ Stripe payment processing is handled via Supabase Edge Functions.
 Create a `.env` file in the project root with your keys:
 
 ```env
-VITE_STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
-VITE_STRIPE_HUURDER_PRICE_ID=<your-huurder-price-id>
+STRIPE_PUBLISHABLE_KEY=<your-publishable-key>
+STRIPE_HUURDER_PRICE_ID=<your-huurder-price-id>
 STRIPE_SECRET_KEY=<your-secret-key>
 STRIPE_WEBHOOK_SECRET=<your-webhook-secret>
 SUPABASE_URL=<your-supabase-url>

--- a/scripts/analyze-tenant-profiles-schema.js
+++ b/scripts/analyze-tenant-profiles-schema.js
@@ -1,8 +1,8 @@
 const { createClient } = require('@supabase/supabase-js');
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/scripts/apply-enhanced-fields-migration.js
+++ b/scripts/apply-enhanced-fields-migration.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
 
 console.log('🔧 Enhanced Profile Fields Migration');
 console.log('URL:', supabaseUrl ? 'Found' : 'Missing');

--- a/scripts/apply-guarantor-timing-migration.js
+++ b/scripts/apply-guarantor-timing-migration.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!supabaseUrl || !supabaseKey) {

--- a/scripts/apply-migrations.js
+++ b/scripts/apply-migrations.js
@@ -6,8 +6,8 @@ import dotenv from 'dotenv';
 // Load environment variables from .env file
 dotenv.config({ path: path.join(process.cwd(), '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseKey) {
   console.error('Missing Supabase credentials');

--- a/scripts/audit-schema.cjs
+++ b/scripts/audit-schema.cjs
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Environment variables
-const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 
 // Create Supabase client with service role

--- a/scripts/audit-schema.js
+++ b/scripts/audit-schema.js
@@ -10,7 +10,7 @@ import fs from 'fs';
 import path from 'path';
 
 // Environment variables
-const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 
 // Create Supabase client with service role

--- a/scripts/check-existing-users.js
+++ b/scripts/check-existing-users.js
@@ -1,8 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
 // Load environment variables
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseKey) {
   console.error('Missing Supabase credentials');

--- a/scripts/comprehensive-database-audit.js
+++ b/scripts/comprehensive-database-audit.js
@@ -3,8 +3,8 @@ import fs from 'fs';
 import path from 'path';
 
 // Load environment variables
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseKey) {
   console.error('Missing Supabase credentials');

--- a/scripts/comprehensive-schema-audit.cjs
+++ b/scripts/comprehensive-schema-audit.cjs
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Environment variables
-const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 // Create Supabase client with service role

--- a/scripts/detailed-connection-analysis.mjs
+++ b/scripts/detailed-connection-analysis.mjs
@@ -11,8 +11,8 @@ dotenv.config({ path: join(__dirname, '..', '.env') });
 console.log('=== DETAILED SUPABASE ANALYSIS ===');
 
 const supabase = createClient(
-  process.env.VITE_SUPABASE_URL,
-  process.env.VITE_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
 );
 
 // Test 1: Check if table exists and get structure
@@ -45,7 +45,7 @@ try {
 console.log('\n2. Testing with service key...');
 try {
   const serviceSupabase = createClient(
-    process.env.VITE_SUPABASE_URL,
+    process.env.SUPABASE_URL,
     process.env.SUPABASE_SERVICE_ROLE_KEY
   );
   

--- a/scripts/direct-table-query.js
+++ b/scripts/direct-table-query.js
@@ -1,8 +1,8 @@
 const { createClient } = require('@supabase/supabase-js');
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 
 console.log('🔍 DIRECT TENANT_PROFILES TABLE ANALYSIS');
 console.log('=' .repeat(60));

--- a/scripts/get-actual-columns.js
+++ b/scripts/get-actual-columns.js
@@ -1,8 +1,8 @@
 const { createClient } = require('@supabase/supabase-js');
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/scripts/postgres-schema-analysis.mjs
+++ b/scripts/postgres-schema-analysis.mjs
@@ -12,8 +12,8 @@ dotenv.config({ path: join(__dirname, '..', '.env') });
 const { Client } = pg;
 
 // Extract connection details from Supabase URL
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 const dbPassword = process.env.SUPABASE_DB_PASSWORD;
 
 console.log('🔍 REAL TENANT_PROFILES SCHEMA ANALYSIS VIA POSTGRES');
@@ -21,7 +21,7 @@ console.log('=' .repeat(70));
 
 if (!supabaseUrl || !dbPassword) {
   console.error('❌ Missing required environment variables');
-  console.log('Required: VITE_SUPABASE_URL, SUPABASE_DB_PASSWORD');
+  console.log('Required: SUPABASE_URL, SUPABASE_DB_PASSWORD');
   process.exit(1);
 }
 

--- a/scripts/real-schema-analysis.js
+++ b/scripts/real-schema-analysis.js
@@ -1,8 +1,8 @@
 const { createClient } = require('@supabase/supabase-js');
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/scripts/schema-analysis-to-file.mjs
+++ b/scripts/schema-analysis-to-file.mjs
@@ -13,7 +13,7 @@ dotenv.config({ path: join(__dirname, '..', '.env') });
 const { Client } = pg;
 
 // Extract connection details from environment
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseUrl = process.env.SUPABASE_URL;
 const dbPassword = process.env.SUPABASE_DB_PASSWORD;
 
 let output = '';
@@ -27,7 +27,7 @@ log('=' .repeat(70));
 
 if (!supabaseUrl || !dbPassword) {
   log('❌ Missing required environment variables');
-  log('Required: VITE_SUPABASE_URL, supabase_DB_Password');
+  log('Required: SUPABASE_URL, supabase_DB_Password');
   process.exit(1);
 }
 

--- a/scripts/simple-schema-check.js
+++ b/scripts/simple-schema-check.js
@@ -1,8 +1,8 @@
 const { createClient } = require('@supabase/supabase-js');
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL;
-const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
-const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const SUPABASE_URL = import.meta.env.SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -93,11 +93,11 @@ function getEnvironmentConfig(): Partial<AppConfig> {
       baseUrl: getEnvVar('VITE_APP_BASE_URL') || defaultConfig.app.baseUrl
     },
     supabase: {
-      url: getEnvVar('VITE_SUPABASE_URL') || '',
-      anonKey: getEnvVar('VITE_SUPABASE_ANON_KEY') || ''
+      url: getEnvVar('SUPABASE_URL') || '',
+      anonKey: getEnvVar('SUPABASE_ANON_KEY') || ''
     },
     stripe: {
-      publishableKey: getEnvVar('VITE_STRIPE_PUBLISHABLE_KEY') || '',
+      publishableKey: getEnvVar('STRIPE_PUBLISHABLE_KEY') || '',
       webhookSecret: getEnvVar('STRIPE_WEBHOOK_SECRET')
     },
     features: {
@@ -132,15 +132,15 @@ export function validateConfig(): { isValid: boolean; errors: string[] } {
 
   // Required environment variables
   if (!config.supabase.url) {
-    errors.push('VITE_SUPABASE_URL is required');
+    errors.push('SUPABASE_URL is required');
   }
 
   if (!config.supabase.anonKey) {
-    errors.push('VITE_SUPABASE_ANON_KEY is required');
+    errors.push('SUPABASE_ANON_KEY is required');
   }
 
   if (config.features.enablePayments && !config.stripe.publishableKey) {
-    errors.push('VITE_STRIPE_PUBLISHABLE_KEY is required when payments are enabled');
+    errors.push('STRIPE_PUBLISHABLE_KEY is required when payments are enabled');
   }
 
   // Validate URLs
@@ -148,7 +148,7 @@ export function validateConfig(): { isValid: boolean; errors: string[] } {
     new URL(config.supabase.url);
   } catch {
     if (config.supabase.url) {
-      errors.push('VITE_SUPABASE_URL must be a valid URL');
+      errors.push('SUPABASE_URL must be a valid URL');
     }
   }
 

--- a/src/lib/stripe-config.ts
+++ b/src/lib/stripe-config.ts
@@ -9,8 +9,8 @@ import { getEnvVar } from './env';
 
 // Stripe configuration loaded from environment variables
 export const STRIPE_CONFIG = {
-  publishableKey: getEnvVar('VITE_STRIPE_PUBLISHABLE_KEY') || '',
-  huurderPriceId: getEnvVar('VITE_STRIPE_HUURDER_PRICE_ID') || '',
+  publishableKey: getEnvVar('STRIPE_PUBLISHABLE_KEY') || '',
+  huurderPriceId: getEnvVar('STRIPE_HUURDER_PRICE_ID') || '',
 };
 
 // Validate configuration

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -5,7 +5,7 @@ import { getEnvVar } from './env.ts';
 
 // Read Stripe configuration from environment variables
 export const STRIPE_CONFIG = {
-  publishableKey: getEnvVar('VITE_STRIPE_PUBLISHABLE_KEY') || '',
+  publishableKey: getEnvVar('STRIPE_PUBLISHABLE_KEY') || '',
 };
 
 // Get publishable key for frontend
@@ -31,7 +31,7 @@ export const getStripe = (): Promise<Stripe | null> => {
 
 // Get environment-configurable price IDs
 const getStripeConfig = () => {
-  const huurderPriceId = getEnvVar('VITE_STRIPE_HUURDER_PRICE_ID') || '';
+  const huurderPriceId = getEnvVar('STRIPE_HUURDER_PRICE_ID') || '';
 
   return {
     huurderPriceId

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { Database } from './database.types'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+const supabaseUrl = import.meta.env.SUPABASE_URL
+const supabaseKey = import.meta.env.SUPABASE_ANON_KEY
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseKey)


### PR DESCRIPTION
## Summary
- rename environment variables to remove the `VITE_` prefix
- update codebase to use `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `STRIPE_PUBLISHABLE_KEY` and `STRIPE_HUURDER_PRICE_ID`
- document new variable names in `.env.example` and README

## Testing
- `npm run lint` *(fails: unexpected any in many files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d73558864832b98ed352a849621a2