### PR TITLE
Fix Supabase env var usage

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
 import { Database } from './database.types'
 
-const supabaseUrl = import.meta.env.SUPABASE_URL
-const supabaseKey = import.meta.env.SUPABASE_ANON_KEY
+// Use the same variable names as our environment variables to avoid confusion
+const SUPABASE_URL = import.meta.env.SUPABASE_URL as string
+const SUPABASE_ANON_KEY = import.meta.env.SUPABASE_ANON_KEY as string
 
-export const supabase = createClient<Database>(supabaseUrl, supabaseKey)
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY)


### PR DESCRIPTION
## Summary
- ensure `src/lib/supabase.ts` uses the same constant names as the env vars

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-explicit-any` errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e35eb3f34832bb026ccefab814c74