### PR TITLE
Add privacy and terms pages

### DIFF
--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -26,6 +26,10 @@
     "decline": "Weigeren",
     "accept": "Accepteren"
   },
+  "pages": {
+    "privacy": "Privacybeleid",
+    "terms": "Algemene Voorwaarden"
+  },
   "login": {
     "title": "Inloggen",
     "email": "E-mailadres",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ const VerhuurderDashboard = lazy(() => import("./pages/VerhuurderDashboard"));
 const BeoordelaarDashboard = lazy(() => import('./pages/BeoordelaarDashboard'));
 const BeheerderDashboard = lazy(() => import('./pages/BeheerderDashboard'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
+const Privacybeleid = lazy(() => import('./pages/Privacybeleid'));
+const AlgemeneVoorwaarden = lazy(() => import('./pages/AlgemeneVoorwaarden'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -78,6 +80,8 @@ const App = () => (
             />
             <Route path="/payment-success" element={<PaymentSuccess />} />
             <Route path="/reset-password" element={<ResetPassword />} />
+            <Route path="/privacybeleid" element={<Privacybeleid />} />
+            <Route path="/algemene-voorwaarden" element={<AlgemeneVoorwaarden />} />
           </Routes>
         </Suspense>
         <CookieConsent />

--- a/src/pages/AlgemeneVoorwaarden.tsx
+++ b/src/pages/AlgemeneVoorwaarden.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const AlgemeneVoorwaarden: React.FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto py-12 px-4 space-y-4">
+      <h1 className="text-2xl font-bold">Algemene Voorwaarden</h1>
+      <p>
+        Deze voorwaarden zijn van toepassing op het gebruik van Huurly. Door je
+        aan te melden ga je akkoord met deze voorwaarden en verklaar je dat je
+        onze dienst eerlijk zult gebruiken.
+      </p>
+      <p>
+        Wij handelen conform de AVG en behandelen persoonsgegevens zorgvuldig. De
+        volledige inhoud van deze voorwaarden kan op verzoek worden toegestuurd.
+      </p>
+      <p>
+        Voor meer informatie of vragen kun je contact opnemen via
+        <a href="mailto:info@huurly.nl" className="text-blue-600 underline">
+          info@huurly.nl
+        </a>
+        .
+      </p>
+    </div>
+  );
+};
+
+export default AlgemeneVoorwaarden;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { Features } from '@/components/Features';
 import { CTA } from '@/components/CTA';
 import { Logo } from '@/components/Logo';
 import { MultiStepSignupModal } from '@/components/auth/MultiStepSignupModal';
+import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
@@ -79,6 +80,16 @@ const Index = () => {
                 <li>Help centrum</li>
                 <li>Contact</li>
                 <li>Veelgestelde vragen</li>
+                <li>
+                  <Link to="/privacybeleid" className="hover:underline">
+                    Privacybeleid
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/algemene-voorwaarden" className="hover:underline">
+                    Algemene Voorwaarden
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>

--- a/src/pages/Privacybeleid.tsx
+++ b/src/pages/Privacybeleid.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const Privacybeleid: React.FC = () => {
+  return (
+    <div className="max-w-3xl mx-auto py-12 px-4 space-y-4">
+      <h1 className="text-2xl font-bold">Privacybeleid</h1>
+      <p>
+        Wij hechten veel waarde aan de bescherming van jouw persoonsgegevens. In
+        dit privacybeleid leggen wij uit hoe Huurly omgaat met jouw gegevens en
+        hoe wij voldoen aan de Algemene Verordening Gegevensbescherming (AVG).
+      </p>
+      <p>
+        Persoonsgegevens worden uitsluitend gebruikt voor het aanbieden van onze
+        dienst. Je gegevens worden niet langer bewaard dan noodzakelijk en nooit
+        zonder toestemming gedeeld met derden.
+      </p>
+      <p>
+        Je hebt het recht om jouw gegevens in te zien, te corrigeren of te
+        verwijderen. Voor vragen over dit beleid kun je contact opnemen via
+        <a href="mailto:info@huurly.nl" className="text-blue-600 underline">
+          info@huurly.nl
+        </a>
+        .
+      </p>
+    </div>
+  );
+};
+
+export default Privacybeleid;


### PR DESCRIPTION
## Summary
- create `Privacybeleid` and `AlgemeneVoorwaarden` pages
- wire them up in the router
- add footer links
- extend Dutch translations for these pages

## Testing
- `npm run lint` *(fails: various existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862b00d9f10832bb7208ed1374d5187