### PR TITLE
Add subscription management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ const VerhuurderDashboard = lazy(() => import("./pages/VerhuurderDashboard"));
 const BeoordelaarDashboard = lazy(() => import('./pages/BeoordelaarDashboard'));
 const BeheerderDashboard = lazy(() => import('./pages/BeheerderDashboard'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
+const ManageSubscription = lazy(() => import('./pages/Subscription/ManageSubscription'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -68,13 +69,21 @@ const App = () => (
                 </ProtectedRoute>
               } 
             />
-            <Route 
-              path="/beheerder-dashboard" 
+            <Route
+              path="/beheerder-dashboard"
               element={
                 <ProtectedRoute roles={['beheerder']}>
                   <BeheerderDashboard />
                 </ProtectedRoute>
-              } 
+              }
+            />
+            <Route
+              path="/subscription"
+              element={
+                <ProtectedRoute roles={['huurder']}>
+                  <ManageSubscription />
+                </ProtectedRoute>
+              }
             />
             <Route path="/payment-success" element={<PaymentSuccess />} />
             <Route path="/reset-password" element={<ResetPassword />} />

--- a/src/pages/HuurderDashboard.tsx
+++ b/src/pages/HuurderDashboard.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from "react";
+import { useNavigate } from 'react-router-dom';
 import { useHuurder } from '@/hooks/useHuurder';
 import { useHuurderActions } from '@/hooks/useHuurderActions';
 import { DashboardHeader, DashboardContent } from "@/components/dashboard";
@@ -37,6 +38,7 @@ const HuurderDashboard: React.FC<HuurderDashboardProps> = ({ user: authUser }) =
     handleProfileComplete,
     handleDocumentUploadComplete,
   } = useHuurder();
+  const navigate = useNavigate();
 
   const { handleSettings, handleLogout, onStartSearch, handleReportIssue, handleHelpSupport } = useHuurderActions(user);
 
@@ -227,6 +229,9 @@ const HuurderDashboard: React.FC<HuurderDashboardProps> = ({ user: authUser }) =
               </Button>
               <Button onClick={handleHelpSupport} className="w-full bg-gray-500 hover:bg-gray-600 text-white">
                 Help & Support
+              </Button>
+              <Button onClick={() => navigate('/subscription')} className="w-full bg-indigo-500 hover:bg-indigo-600 text-white">
+                Abonnement
               </Button>
             </div>
           </DashboardContent>

--- a/src/pages/Subscription/ManageSubscription.tsx
+++ b/src/pages/Subscription/ManageSubscription.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { subscriptionService, SubscriptionStatus } from '@/services/payment/SubscriptionService';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/hooks/use-toast';
+
+const ManageSubscription = () => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<SubscriptionStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [processing, setProcessing] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user?.id) return;
+      setLoading(true);
+      const result = await subscriptionService.checkSubscriptionStatus(user.id);
+      if (result.success && result.data) {
+        setStatus(result.data);
+      } else {
+        toast({ title: 'Fout', description: result.error?.message || 'Kon abonnement niet laden', variant: 'destructive' });
+      }
+      setLoading(false);
+    };
+    load();
+  }, [user]);
+
+  const cancel = async () => {
+    if (!status?.stripeSubscriptionId) return;
+    setProcessing(true);
+    const result = await subscriptionService.cancelSubscription(status.stripeSubscriptionId);
+    if (result.success) {
+      toast({ title: 'Abonnement wordt geannuleerd', description: 'Je behoudt toegang tot het einde van de huidige periode.' });
+    } else {
+      toast({ title: 'Fout', description: result.error?.message || 'Annuleren mislukt', variant: 'destructive' });
+    }
+    setProcessing(false);
+  };
+
+  const renew = async () => {
+    if (!status?.stripeSubscriptionId) return;
+    setProcessing(true);
+    const result = await subscriptionService.renewSubscription(status.stripeSubscriptionId);
+    if (result.success) {
+      toast({ title: 'Abonnement hervat', description: 'Je abonnement is opnieuw geactiveerd.' });
+    } else {
+      toast({ title: 'Fout', description: result.error?.message || 'Herstart mislukt', variant: 'destructive' });
+    }
+    setProcessing(false);
+  };
+
+  if (loading) {
+    return <div className="p-4">Laden...</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <Button variant="outline" onClick={() => navigate(-1)}>Terug</Button>
+      <h1 className="text-2xl font-bold">Mijn Abonnement</h1>
+      {status?.hasActiveSubscription ? (
+        <div className="space-y-2">
+          <p>Je abonnement verloopt op {status.expiresAt}</p>
+          <Button onClick={cancel} disabled={processing}>Abonnement opzeggen</Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p>Je hebt momenteel geen actief abonnement.</p>
+          {status?.stripeSubscriptionId && (
+            <Button onClick={renew} disabled={processing}>Abonnement hervatten</Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ManageSubscription;

--- a/src/services/payment/SubscriptionService.ts
+++ b/src/services/payment/SubscriptionService.ts
@@ -8,6 +8,7 @@ export interface SubscriptionStatus {
   hasActiveSubscription: boolean;
   subscriptionType?: string;
   expiresAt?: string;
+  stripeSubscriptionId?: string;
 }
 
 export class SubscriptionService extends DatabaseService {
@@ -32,9 +33,28 @@ export class SubscriptionService extends DatabaseService {
           hasActiveSubscription,
           subscriptionType: hasActiveSubscription ? 'yearly' : undefined,
           expiresAt: hasActiveSubscription ? data[0].eind_datum : undefined,
+          stripeSubscriptionId: hasActiveSubscription ? data[0].stripe_subscription_id : undefined,
         } as SubscriptionStatus,
         error: null,
       };
+    });
+  }
+
+  async cancelSubscription(subscriptionId: string): Promise<DatabaseResponse<any>> {
+    return this.executeQuery(async () => {
+      const { data, error } = await supabase.functions.invoke('manage-subscription', {
+        body: { action: 'cancel', subscriptionId }
+      });
+      return { data, error };
+    });
+  }
+
+  async renewSubscription(subscriptionId: string): Promise<DatabaseResponse<any>> {
+    return this.executeQuery(async () => {
+      const { data, error } = await supabase.functions.invoke('manage-subscription', {
+        body: { action: 'resume', subscriptionId }
+      });
+      return { data, error };
     });
   }
 }

--- a/supabase/functions/manage-subscription/deno.jsonc
+++ b/supabase/functions/manage-subscription/deno.jsonc
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "lib": ["deno.window"],
+    "strict": false
+  },
+  "imports": {
+    "http/server": "https://deno.land/std@0.190.0/http/server.ts",
+    "stripe": "https://esm.sh/stripe@14.21.0",
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.0"
+  },
+  "tasks": {
+    "dev": "deno run --allow-net --allow-env --allow-read index.ts"
+  }
+}

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -1,0 +1,56 @@
+import { serve } from "http/server";
+import Stripe from "stripe";
+import { createClient } from "@supabase/supabase-js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405, headers: corsHeaders });
+  }
+
+  try {
+    const { action, subscriptionId } = await req.json();
+
+    if (!subscriptionId || !action) {
+      return new Response("Invalid request", { status: 400, headers: corsHeaders });
+    }
+
+    const stripe = new Stripe(Deno.env.get("STRIPE_SECRET_KEY") || "", { apiVersion: "2023-10-16" });
+
+    let subscription: Stripe.Subscription;
+    if (action === "cancel") {
+      subscription = await stripe.subscriptions.update(subscriptionId, { cancel_at_period_end: true });
+    } else if (action === "resume") {
+      subscription = await stripe.subscriptions.update(subscriptionId, { cancel_at_period_end: false });
+    } else {
+      return new Response("Unknown action", { status: 400, headers: corsHeaders });
+    }
+
+    // Optionally update in Supabase - webhook will handle final status
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      { auth: { persistSession: false } }
+    );
+    await supabase.from("abonnementen").update({ status: subscription.status }).eq("stripe_subscription_id", subscription.id);
+
+    return new Response(JSON.stringify({ status: subscription.status }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (err) {
+    console.error("manage-subscription error", err);
+    return new Response(JSON.stringify({ error: err.message }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add Stripe-based subscription management edge function
- extend `SubscriptionService` to cancel or resume subscriptions
- add subscription management page
- show new management button on tenant dashboard
- route `/subscription` for signed-in huurders

## Testing
- `npm run lint` *(fails: prefer-const and no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862b007c50c832bba8622ee74865eec