### PR TITLE
Add tenant search with favorites

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ const VerhuurderDashboard = lazy(() => import("./pages/VerhuurderDashboard"));
 const BeoordelaarDashboard = lazy(() => import('./pages/BeoordelaarDashboard'));
 const BeheerderDashboard = lazy(() => import('./pages/BeheerderDashboard'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
+const ZoekHuurders = lazy(() => import('./pages/ZoekHuurders'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -52,16 +53,24 @@ const App = () => (
                 </ProtectedRoute>
               } 
             />
-            <Route 
-              path="/verhuurder-dashboard" 
+            <Route
+              path="/verhuurder-dashboard"
               element={
                 <ProtectedRoute roles={['verhuurder']}>
                   <VerhuurderDashboard />
                 </ProtectedRoute>
-              } 
+              }
             />
-            <Route 
-              path="/beoordelaar-dashboard" 
+            <Route
+              path="/huurders-zoeken"
+              element={
+                <ProtectedRoute roles={['verhuurder']}>
+                  <ZoekHuurders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/beoordelaar-dashboard"
               element={
                 <ProtectedRoute roles={['beoordelaar']}>
                   <BeoordelaarDashboard />

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -512,6 +512,42 @@ export type Database = {
           },
         ]
       }
+      opgeslagen_profielen: {
+        Row: {
+          aangemaakt_op: string
+          id: string
+          verhuurder_id: string | null
+          huurder_id: string | null
+        }
+        Insert: {
+          aangemaakt_op?: string
+          id?: string
+          verhuurder_id?: string | null
+          huurder_id?: string | null
+        }
+        Update: {
+          aangemaakt_op?: string
+          id?: string
+          verhuurder_id?: string | null
+          huurder_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "opgeslagen_profielen_verhuurder_id_fkey"
+            columns: ["verhuurder_id"]
+            isOneToOne: false
+            referencedRelation: "verhuurders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "opgeslagen_profielen_huurder_id_fkey"
+            columns: ["huurder_id"]
+            isOneToOne: false
+            referencedRelation: "huurders"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       verhuurders: {
         Row: {
           aangemaakt_op: string
@@ -732,6 +768,16 @@ export type Database = {
       filename_prefix: {
         Args: { name: string }
         Returns: string
+      }
+      zoek_huurders: {
+        Args: {
+          in_city?: string | null
+          min_budget?: number | null
+          max_budget?: number | null
+          huisdieren?: boolean | null
+          roken?: boolean | null
+        }
+        Returns: Tables<'actieve_huurders'>[]
       }
     }
     Enums: {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -512,6 +512,42 @@ export type Database = {
           },
         ]
       }
+      opgeslagen_profielen: {
+        Row: {
+          aangemaakt_op: string
+          id: string
+          verhuurder_id: string | null
+          huurder_id: string | null
+        }
+        Insert: {
+          aangemaakt_op?: string
+          id?: string
+          verhuurder_id?: string | null
+          huurder_id?: string | null
+        }
+        Update: {
+          aangemaakt_op?: string
+          id?: string
+          verhuurder_id?: string | null
+          huurder_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "opgeslagen_profielen_verhuurder_id_fkey"
+            columns: ["verhuurder_id"]
+            isOneToOne: false
+            referencedRelation: "verhuurders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "opgeslagen_profielen_huurder_id_fkey"
+            columns: ["huurder_id"]
+            isOneToOne: false
+            referencedRelation: "huurders"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       verhuurders: {
         Row: {
           aangemaakt_op: string
@@ -769,6 +805,16 @@ export type Database = {
           user_telefoon?: string
         }
         Returns: undefined
+      }
+      zoek_huurders: {
+        Args: {
+          in_city?: string | null
+          min_budget?: number | null
+          max_budget?: number | null
+          huisdieren?: boolean | null
+          roken?: boolean | null
+        }
+        Returns: Tables<'actieve_huurders'>[]
       }
     }
     Enums: {

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -1,0 +1,61 @@
+export interface LifestyleFilters {
+  huisdieren?: boolean;
+  roken?: boolean;
+}
+
+export interface SearchCriteria {
+  city?: string;
+  minBudget?: number;
+  maxBudget?: number;
+  lifestyle?: LifestyleFilters;
+}
+
+export interface CompatibilityResult {
+  location: number;
+  budget: number;
+  lifestyle: number;
+  total: number;
+}
+
+export function computeCompatibility(tenant: any, criteria: SearchCriteria): CompatibilityResult {
+  let location = 0;
+  if (criteria.city && Array.isArray(tenant.locatie_voorkeur)) {
+    location = tenant.locatie_voorkeur.includes(criteria.city) ? 100 : 0;
+  }
+
+  let budget = 0;
+  if (criteria.minBudget !== undefined || criteria.maxBudget !== undefined) {
+    const max = tenant.max_huur ?? 0;
+    if (
+      (criteria.minBudget === undefined || max >= criteria.minBudget) &&
+      (criteria.maxBudget === undefined || max <= criteria.maxBudget)
+    ) {
+      budget = 100;
+    } else if (criteria.maxBudget) {
+      const diff = Math.abs(max - criteria.maxBudget);
+      budget = Math.max(0, 100 - diff / criteria.maxBudget * 100);
+    }
+  }
+
+  let lifestyleCount = 0;
+  let lifestyleScore = 0;
+  if (criteria.lifestyle) {
+    if (criteria.lifestyle.huisdieren !== undefined) {
+      lifestyleCount++;
+      if (tenant.huisdieren === criteria.lifestyle.huisdieren) lifestyleScore++;
+    }
+    if (criteria.lifestyle.roken !== undefined) {
+      lifestyleCount++;
+      if (tenant.roken === criteria.lifestyle.roken) lifestyleScore++;
+    }
+  }
+  const lifestyle = lifestyleCount ? (lifestyleScore / lifestyleCount) * 100 : 0;
+
+  const total = (location + budget + lifestyle) / 3;
+  return {
+    location: Math.round(location),
+    budget: Math.round(budget),
+    lifestyle: Math.round(lifestyle),
+    total: Math.round(total)
+  };
+}

--- a/src/pages/ZoekHuurders.tsx
+++ b/src/pages/ZoekHuurders.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { withAuth } from '@/hocs/withAuth';
+import { User } from '@/types';
+import { computeCompatibility, SearchCriteria } from '@/lib/matching';
+import { favoritesService } from '@/services/FavoritesService';
+import { logger } from '@/lib/logger';
+
+interface ZoekHuurdersProps {
+  user: User;
+}
+
+const ZoekHuurders: React.FC<ZoekHuurdersProps> = ({ user }) => {
+  const [city, setCity] = useState('');
+  const [minBudget, setMinBudget] = useState<number | undefined>();
+  const [maxBudget, setMaxBudget] = useState<number | undefined>();
+  const [pets, setPets] = useState<boolean | undefined>();
+  const [smoking, setSmoking] = useState<boolean | undefined>();
+  const [results, setResults] = useState<any[]>([]);
+  const [saved, setSaved] = useState<string[]>([]);
+
+  useEffect(() => {
+    const loadSaved = async () => {
+      const res = await favoritesService.listSavedProfiles(user.id);
+      if (res.success && res.data) setSaved(res.data);
+    };
+    loadSaved();
+  }, [user.id]);
+
+  const handleSearch = async () => {
+    const { data, error } = await supabase.rpc('zoek_huurders', {
+      in_city: city || null,
+      min_budget: minBudget ?? null,
+      max_budget: maxBudget ?? null,
+      huisdieren: typeof pets === 'boolean' ? pets : null,
+      roken: typeof smoking === 'boolean' ? smoking : null,
+    });
+
+    if (error) {
+      logger.error('Search error', error);
+      setResults([]);
+      return;
+    }
+
+    const criteria: SearchCriteria = {
+      city: city || undefined,
+      minBudget,
+      maxBudget,
+      lifestyle: { huisdieren: pets, roken: smoking },
+    };
+
+    const enriched = (data || []).map((t: any) => ({
+      ...t,
+      compatibility: computeCompatibility(t, criteria),
+    }));
+    setResults(enriched);
+  };
+
+  const handleSave = async (tenantId: string) => {
+    const res = await favoritesService.saveProfile(user.id, tenantId);
+    if (res.success) setSaved((prev) => [...prev, tenantId]);
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Zoek Huurders</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+        <input
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          placeholder="Plaats"
+          className="border p-2 rounded"
+        />
+        <input
+          type="number"
+          value={minBudget ?? ''}
+          onChange={(e) => setMinBudget(e.target.value ? parseInt(e.target.value) : undefined)}
+          placeholder="Min. Budget"
+          className="border p-2 rounded"
+        />
+        <input
+          type="number"
+          value={maxBudget ?? ''}
+          onChange={(e) => setMaxBudget(e.target.value ? parseInt(e.target.value) : undefined)}
+          placeholder="Max. Budget"
+          className="border p-2 rounded"
+        />
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={pets ?? false} onChange={(e) => setPets(e.target.checked)} />
+          <span>Huisdieren</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" checked={smoking ?? false} onChange={(e) => setSmoking(e.target.checked)} />
+          <span>Roken</span>
+        </label>
+      </div>
+      <button onClick={handleSearch} className="px-4 py-2 bg-blue-600 text-white rounded">
+        Zoeken
+      </button>
+      <div className="mt-6 overflow-x-auto">
+        {results.length === 0 ? (
+          <p>Geen resultaten</p>
+        ) : (
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-3 py-2 text-left text-sm">Naam</th>
+                <th className="px-3 py-2 text-left text-sm">Max Budget</th>
+                <th className="px-3 py-2 text-left text-sm">Compatibiliteit</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {results.map((r) => (
+                <tr key={r.id}>
+                  <td className="px-3 py-2">{r.naam}</td>
+                  <td className="px-3 py-2">€{r.max_huur}</td>
+                  <td className="px-3 py-2">{r.compatibility.total}%</td>
+                  <td className="px-3 py-2">
+                    {saved.includes(r.id) ? (
+                      <span className="text-green-600">Opgeslagen</span>
+                    ) : (
+                      <button
+                        onClick={() => handleSave(r.id)}
+                        className="text-blue-600 hover:underline"
+                      >
+                        Opslaan
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default withAuth(ZoekHuurders, 'verhuurder');

--- a/src/services/FavoritesService.ts
+++ b/src/services/FavoritesService.ts
@@ -1,0 +1,38 @@
+import { supabase } from '../integrations/supabase/client';
+import { DatabaseService, DatabaseResponse } from '../lib/database';
+import { logger } from '../lib/logger';
+
+export class FavoritesService extends DatabaseService {
+  async listSavedProfiles(landlordId: string): Promise<DatabaseResponse<string[]>> {
+    return this.executeQuery(async () => {
+      const { data, error } = await supabase
+        .from('opgeslagen_profielen')
+        .select('huurder_id')
+        .eq('verhuurder_id', landlordId);
+      const ids = data ? data.map((d) => d.huurder_id) : [];
+      return { data: ids as string[], error };
+    });
+  }
+
+  async saveProfile(landlordId: string, tenantId: string): Promise<DatabaseResponse<null>> {
+    return this.executeQuery(async () => {
+      const { error } = await supabase
+        .from('opgeslagen_profielen')
+        .insert({ verhuurder_id: landlordId, huurder_id: tenantId });
+      return { data: null, error };
+    });
+  }
+
+  async removeProfile(landlordId: string, tenantId: string): Promise<DatabaseResponse<null>> {
+    return this.executeQuery(async () => {
+      const { error } = await supabase
+        .from('opgeslagen_profielen')
+        .delete()
+        .eq('verhuurder_id', landlordId)
+        .eq('huurder_id', tenantId);
+      return { data: null, error };
+    });
+  }
+}
+
+export const favoritesService = new FavoritesService();

--- a/supabase/migrations/20250715000000_create_opgeslagen_profielen_and_search_rpc.sql
+++ b/supabase/migrations/20250715000000_create_opgeslagen_profielen_and_search_rpc.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS public.opgeslagen_profielen (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    verhuurder_id uuid REFERENCES public.verhuurders(id) ON DELETE CASCADE,
+    huurder_id uuid REFERENCES public.huurders(id) ON DELETE CASCADE,
+    aangemaakt_op timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.opgeslagen_profielen ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Landlord owns saved profiles" ON public.opgeslagen_profielen
+USING (auth.uid() = verhuurder_id)
+WITH CHECK (auth.uid() = verhuurder_id);
+
+CREATE OR REPLACE FUNCTION public.zoek_huurders(
+    in_city text DEFAULT NULL,
+    min_budget integer DEFAULT NULL,
+    max_budget integer DEFAULT NULL,
+    huisdieren boolean DEFAULT NULL,
+    roken boolean DEFAULT NULL
+)
+RETURNS SETOF public.actieve_huurders
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT * FROM public.actieve_huurders h
+  WHERE (in_city IS NULL OR in_city = ANY(h.locatie_voorkeur))
+    AND (min_budget IS NULL OR h.max_huur >= min_budget)
+    AND (max_budget IS NULL OR h.max_huur <= max_budget)
+    AND (huisdieren IS NULL OR h.huisdieren = huisdieren)
+    AND (roken IS NULL OR h.roken = roken);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.zoek_huurders(text, integer, integer, boolean, boolean) TO authenticated, anon;


### PR DESCRIPTION
## Summary
- create SearchHuurders page with filters and favorite actions
- implement matching utility for compatibility scores
- add FavoritesService to manage saved profiles
- create migration for `opgeslagen_profielen` table and search RPC
- expose RPC and table types
- route landlord search page via `/huurders-zoeken`

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_6862b00a0754832bb92f0b77a450f78a