### PR TITLE
Fix payment success redirect

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,8 +24,7 @@ const Index = () => {
     setShowEmailConfirmationModal,
     setShowEmailVerificationSuccessModal,
     setShowPaymentSuccessModal,
-    handleEmailVerificationSuccess,
-    handlePaymentSuccess
+    handleEmailVerificationSuccess
   } = useAuth();
   const navigate = useNavigate();
   const [showSignup, setShowSignup] = useState(false);
@@ -57,17 +56,10 @@ const Index = () => {
       return;
     }
 
-    // Check for payment success
+    // Legacy support: redirect old payment success URLs to the new route
     if (searchParams.get('payment') === 'success') {
-      console.log('Payment success detected');
       const sessionId = searchParams.get('session_id');
-      if (sessionId) {
-        // Handle payment success with session ID if needed
-        console.log('Processing payment success for session:', sessionId);
-      }
-      handlePaymentSuccess();
-      // Clean up URL
-      window.history.replaceState({}, document.title, window.location.pathname);
+      navigate(`/payment-success${sessionId ? `?session_id=${sessionId}` : ''}`);
       return;
     }
 
@@ -89,7 +81,7 @@ const Index = () => {
           break;
       }
     }
-  }, [isAuthenticated, user, navigate, handleEmailVerificationSuccess, handlePaymentSuccess]);
+  }, [isAuthenticated, user, navigate, handleEmailVerificationSuccess]);
 
   return (
     <div className="min-h-screen">

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -43,7 +43,7 @@ const PaymentSuccess = () => {
 
           const timeout = setTimeout(() => {
             console.log("Redirecting to dashboard");
-            navigate("/huurder-dashboard");
+            navigate("/huurder-dashboard?payment_success=true");
           }, 3000);
 
           return () => clearTimeout(timeout);
@@ -97,7 +97,7 @@ const PaymentSuccess = () => {
           </div>
           <h1 className="text-2xl font-bold text-gray-900 mb-2">Betaling Mislukt</h1>
           <p className="text-red-600 mb-6">{error}</p>
-          <button onClick={() => navigate('/huurder-dashboard')} className="bg-dutch-blue text-white px-4 py-2 rounded">
+          <button onClick={() => navigate('/huurder-dashboard?payment_success=true')} className="bg-dutch-blue text-white px-4 py-2 rounded">
             Terug naar Dashboard
           </button>
         </div>

--- a/src/services/payment/StripeCheckoutService.ts
+++ b/src/services/payment/StripeCheckoutService.ts
@@ -45,7 +45,7 @@ export class StripeCheckoutService extends DatabaseService {
 
         logger.info('Betaalrecord aangemaakt:', { paymentRecordId: paymentRecord.id });
 
-        const successUrl = `${baseUrl}/?payment=success&session_id={CHECKOUT_SESSION_ID}`;
+        const successUrl = `${baseUrl}/payment-success?session_id={CHECKOUT_SESSION_ID}`;
         const cancelUrl = `${baseUrl}/huurder-dashboard?payment=cancelled`;
 
         const { data, error } = await supabase.functions.invoke('create-checkout-session', {


### PR DESCRIPTION
## Summary
- redirect Stripe checkout success to `/payment-success` so the session gets processed
- redirect legacy `payment=success` URLs to the new payment success page
- forward to dashboard with `payment_success=true` once the session is handled

## Testing
- `npm install`
- `npm run lint` *(fails: unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686b7b9091c0832b910bb185fc0dc162