### PR TITLE
Fix signup toast message

### DIFF
--- a/src/components/auth/MultiStepSignupModal.tsx
+++ b/src/components/auth/MultiStepSignupModal.tsx
@@ -60,7 +60,7 @@ export const MultiStepSignupModal = ({ isOpen, onClose }: MultiStepSignupModalPr
       if (success && user) {
         toast({
           title: "Registratie succesvol!",
-          description: "Je wordt doorgestuurd naar je dashboard.",
+          description: "Er is een e-mail verzonden om je account te bevestigen.",
         });
         onClose();
 


### PR DESCRIPTION
## Summary
- correct toast copy after signup to mention the confirmation email

## Testing
- `npm run lint` *(fails: unexpected any etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b88353404832bb6fb0df64accc07f