### PR TITLE
Add migration for unique stripe subscription id

### DIFF
--- a/supabase/migrations/20250707085235_add_unique_stripe_subscription_id.sql
+++ b/supabase/migrations/20250707085235_add_unique_stripe_subscription_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.abonnementen
+  ADD CONSTRAINT abonnementen_stripe_subscription_id_key UNIQUE (stripe_subscription_id);


### PR DESCRIPTION
## Summary
- create migration to add a unique constraint on `stripe_subscription_id`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8a5f21cc832ba4627a41716a04cd