### PR TITLE
Fix stripe webhook event verification

### DIFF
--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -68,7 +68,7 @@ serve(async (req) => {
 
     let event;
     try {
-      event = stripe.webhooks.constructEventAsync(body, signature, webhookSecret);
+      event = await stripe.webhooks.constructEventAsync(body, signature, webhookSecret);
       console.log("✅ Verified Stripe event:", event.type);
     } catch (err) {
       console.error("❌ Webhook signature verification failed:", err.message);


### PR DESCRIPTION
## Summary
- await Stripe constructEventAsync to properly verify webhook

## Testing
- `npm run lint` *(fails: unexpected any rules)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e22da718c832bbe016dba032d1dc6