### PR TITLE
Add shared password validation util and live checks

### DIFF
--- a/src/components/auth/MultiStepSignupModal.tsx
+++ b/src/components/auth/MultiStepSignupModal.tsx
@@ -7,18 +7,13 @@ import { Label } from '@/components/ui/label';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/components/ui/use-toast';
 import { Loader2, Check } from 'lucide-react';
+import { validatePassword, type PasswordValidation } from '@/utils/password';
 
 interface MultiStepSignupModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-interface PasswordValidation {
-  minLength: boolean;
-  hasUppercase: boolean;
-  hasLowercase: boolean;
-  hasNumber: boolean;
-}
 
 export const MultiStepSignupModal = ({ isOpen, onClose }: MultiStepSignupModalProps) => {
   const [step, setStep] = useState(1);
@@ -43,15 +38,6 @@ export const MultiStepSignupModal = ({ isOpen, onClose }: MultiStepSignupModalPr
     hasNumber: false
   });
 
-  // Function to validate password requirements
-  const validatePassword = (password: string): PasswordValidation => {
-    return {
-      minLength: password.length >= 8,
-      hasUppercase: /[A-Z]/.test(password),
-      hasLowercase: /[a-z]/.test(password),
-      hasNumber: /[0-9]/.test(password)
-    };
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Check } from 'lucide-react';
+import { validatePassword, type PasswordValidation } from '@/utils/password';
 
 import { useAuth } from '@/hooks/useAuth';
 
@@ -17,6 +19,12 @@ export const SignupForm = ({ onClose }: SignupFormProps) => {
     password: '',
     firstName: '',
     lastName: ''
+  });
+  const [passwordValidation, setPasswordValidation] = useState<PasswordValidation>({
+    minLength: false,
+    hasUppercase: false,
+    hasLowercase: false,
+    hasNumber: false,
   });
   const [isLoading, setIsLoading] = useState(false);
   const { signUp } = useAuth();
@@ -39,6 +47,17 @@ export const SignupForm = ({ onClose }: SignupFormProps) => {
       setIsLoading(false);
     }
   };
+
+  const PasswordRequirement = ({ met, children }: { met: boolean; children: React.ReactNode }) => (
+    <li className={`flex items-center space-x-2 ${met ? 'text-green-600' : 'text-gray-600'}`}>
+      {met ? (
+        <Check className="w-3 h-3 text-green-600" />
+      ) : (
+        <span className="w-3 h-3 rounded-full border border-gray-400"></span>
+      )}
+      <span>{children}</span>
+    </li>
+  );
 
   return (
     <div className="space-y-6">
@@ -91,18 +110,22 @@ export const SignupForm = ({ onClose }: SignupFormProps) => {
             id="password"
             type="password"
             value={formData.password}
-            onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+            onChange={(e) => {
+              const value = e.target.value;
+              setFormData({ ...formData, password: value });
+              setPasswordValidation(validatePassword(value));
+            }}
             required
             placeholder="••••••••"
             minLength={8}
           />
-          <div className="mt-2 text-xs text-gray-600 space-y-1">
-            <p>Wachtwoord moet bevatten:</p>
-            <ul className="list-disc list-inside space-y-0.5 ml-2">
-              <li>Minimaal 8 karakters</li>
-              <li>Minimaal 1 hoofdletter (A-Z)</li>
-              <li>Minimaal 1 kleine letter (a-z)</li>
-              <li>Minimaal 1 cijfer (0-9)</li>
+          <div className="mt-2 text-xs space-y-1">
+            <p className="text-gray-700 font-medium">Wachtwoord moet bevatten:</p>
+            <ul className="space-y-1 ml-2">
+              <PasswordRequirement met={passwordValidation.minLength}>Minimaal 8 karakters</PasswordRequirement>
+              <PasswordRequirement met={passwordValidation.hasUppercase}>Minimaal 1 hoofdletter (A-Z)</PasswordRequirement>
+              <PasswordRequirement met={passwordValidation.hasLowercase}>Minimaal 1 kleine letter (a-z)</PasswordRequirement>
+              <PasswordRequirement met={passwordValidation.hasNumber}>Minimaal 1 cijfer (0-9)</PasswordRequirement>
             </ul>
           </div>
         </div>

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,13 @@
+export interface PasswordValidation {
+  minLength: boolean;
+  hasUppercase: boolean;
+  hasLowercase: boolean;
+  hasNumber: boolean;
+}
+
+export const validatePassword = (password: string): PasswordValidation => ({
+  minLength: password.length >= 8,
+  hasUppercase: /[A-Z]/.test(password),
+  hasLowercase: /[a-z]/.test(password),
+  hasNumber: /[0-9]/.test(password),
+});


### PR DESCRIPTION
## Summary
- add `validatePassword` util for shared password requirements
- use new util in `MultiStepSignupModal`
- show real-time password checks in `SignupForm`

## Testing
- `npm run lint` *(fails: cannot pass eslint due to existing project errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e512192b0832babc474c207c98f88