### PR TITLE
Drop abonnement_actief column

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -472,7 +472,6 @@ export type Database = {
       huurders: {
         Row: {
           aangemaakt_op: string
-          abonnement_actief: boolean | null
           abonnement_start: string | null
           abonnement_verloopt: string | null
           beroep: string | null
@@ -503,7 +502,6 @@ export type Database = {
         }
         Insert: {
           aangemaakt_op?: string
-          abonnement_actief?: boolean | null
           abonnement_start?: string | null
           abonnement_verloopt?: string | null
           beroep?: string | null
@@ -534,7 +532,6 @@ export type Database = {
         }
         Update: {
           aangemaakt_op?: string
-          abonnement_actief?: boolean | null
           abonnement_start?: string | null
           abonnement_verloopt?: string | null
           beroep?: string | null
@@ -880,7 +877,6 @@ export type Database = {
     Views: {
       actieve_huurders: {
         Row: {
-          abonnement_actief: boolean | null
           abonnement_start: string | null
           abonnement_verloopt: string | null
           beroep: string | null

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -256,7 +256,6 @@ export type Database = {
       huurders: {
         Row: {
           aangemaakt_op: string
-          abonnement_actief: boolean | null
           abonnement_start: string | null
           abonnement_verloopt: string | null
           beroep: string | null
@@ -287,7 +286,6 @@ export type Database = {
         }
         Insert: {
           aangemaakt_op?: string
-          abonnement_actief?: boolean | null
           abonnement_start?: string | null
           abonnement_verloopt?: string | null
           beroep?: string | null
@@ -318,7 +316,6 @@ export type Database = {
         }
         Update: {
           aangemaakt_op?: string
-          abonnement_actief?: boolean | null
           abonnement_start?: string | null
           abonnement_verloopt?: string | null
           beroep?: string | null
@@ -661,7 +658,6 @@ export type Database = {
     Views: {
       actieve_huurders: {
         Row: {
-          abonnement_actief: boolean | null
           abonnement_start: string | null
           abonnement_verloopt: string | null
           beroep: string | null

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -469,7 +469,6 @@ export type Database = {
       huurders: {
         Row: {
           aangemaakt_op: string
-          abonnement_actief: boolean | null
           abonnement_start: string | null
           abonnement_verloopt: string | null
           beroep: string | null
@@ -500,7 +499,6 @@ export type Database = {
         }
         Insert: {
           aangemaakt_op?: string
-          abonnement_actief?: boolean | null
           abonnement_start?: string | null
           abonnement_verloopt?: string | null
           beroep?: string | null
@@ -531,7 +529,6 @@ export type Database = {
         }
         Update: {
           aangemaakt_op?: string
-          abonnement_actief?: boolean | null
           abonnement_start?: string | null
           abonnement_verloopt?: string | null
           beroep?: string | null
@@ -877,7 +874,6 @@ export type Database = {
     Views: {
       actieve_huurders: {
         Row: {
-          abonnement_actief: boolean | null
           abonnement_start: string | null
           abonnement_verloopt: string | null
           beroep: string | null

--- a/supabase/migrations/20250707170000_fix_rls_security_vulnerabilities.sql
+++ b/supabase/migrations/20250707170000_fix_rls_security_vulnerabilities.sql
@@ -151,11 +151,14 @@ AS SELECT
   h.locatie_voorkeur,
   h.profielfoto_url,
   h.beschrijving,
-  h.abonnement_actief,
   h.aangemaakt_op
 FROM public.huurders h
 JOIN public.gebruikers g ON h.id = g.id
-WHERE h.abonnement_actief = true
+WHERE EXISTS (
+    SELECT 1 FROM public.abonnementen a
+    WHERE a.huurder_id = h.id
+      AND a.status = 'actief'
+  )
   AND g.profiel_compleet = true;
 
 -- Revoke all access from anon and authenticated, only allow specific roles

--- a/supabase/migrations/20250716000000_create_core_tables.sql
+++ b/supabase/migrations/20250716000000_create_core_tables.sql
@@ -53,7 +53,6 @@ CREATE TABLE IF NOT EXISTS public.huurders (
     partner boolean,
     profielfoto_url text,
     roken boolean,
-    abonnement_actief boolean,
     abonnement_start text,
     abonnement_verloopt text,
     voorkeur_verhuisdatum text,

--- a/supabase/migrations/20250719000000_drop_huurders_abonnement_actief.sql
+++ b/supabase/migrations/20250719000000_drop_huurders_abonnement_actief.sql
@@ -1,0 +1,36 @@
+-- Remove obsolete abonnement_actief column and update actieve_huurders view
+ALTER TABLE public.huurders DROP COLUMN IF EXISTS abonnement_actief;
+
+DROP VIEW IF EXISTS public.actieve_huurders;
+DROP POLICY IF EXISTS "actieve_huurders_verhuurders_only" ON public.actieve_huurders;
+
+CREATE VIEW public.actieve_huurders
+WITH (security_invoker = true)
+AS
+SELECT
+  h.id,
+  g.naam,
+  g.email,
+  h.beroep,
+  h.inkomen,
+  h.max_huur,
+  h.locatie_voorkeur,
+  h.profielfoto_url,
+  h.beschrijving,
+  h.aangemaakt_op
+FROM public.huurders h
+JOIN public.gebruikers g ON h.id = g.id
+WHERE EXISTS (
+    SELECT 1 FROM public.abonnementen a
+    WHERE a.huurder_id = h.id
+      AND a.status = 'actief'
+  )
+  AND g.profiel_compleet = true;
+
+REVOKE ALL ON public.actieve_huurders FROM anon, authenticated;
+GRANT SELECT ON public.actieve_huurders TO authenticated;
+
+CREATE POLICY "actieve_huurders_verhuurders_only" ON public.actieve_huurders
+  FOR SELECT USING (
+    public.get_user_role(auth.uid()) IN ('verhuurder', 'admin')
+  );


### PR DESCRIPTION
## Summary
- remove `abonnement_actief` from initial tables
- adjust `actieve_huurders` view to check `abonnementen` status
- create migration to drop the column and recreate the view
- sync generated TypeScript types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e5166c5f8832b99ef13124529cb03