### PR TITLE
Map structured tenant profile

### DIFF
--- a/src/hooks/useHuurder.ts
+++ b/src/hooks/useHuurder.ts
@@ -36,11 +36,11 @@ export const useHuurder = () => {
       const response = await consolidatedDashboardService.getHuurderDashboardData(user.id);
       
       if (response.success && response.data) {
-        const { stats, documents, tenantProfile, subscription, profilePictureUrl, hasProfile } = response.data;
+        const { stats, documents, tenantProfile: mappedProfile, subscription, profilePictureUrl, hasProfile } = response.data;
         
         setStats(stats);
         setUserDocuments(Array.isArray(documents) ? documents : []);
-        setTenantProfile(tenantProfile);
+        setTenantProfile(mappedProfile);
         setSubscription(subscription);
         setProfilePictureUrl(profilePictureUrl);
         setHasProfile(hasProfile);


### PR DESCRIPTION
## Summary
- map raw `huurders` and `gebruikers` rows to a structured `TenantProfile`
- fetch `gebruikers` info when loading dashboard data
- return mapped profile and store it from `useHuurder`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e65a53de0832b84f5087b5f6b95ea