### PR TITLE
Add parking_required support

### DIFF
--- a/src/components/HuurderDashboard/DashboardModals.tsx
+++ b/src/components/HuurderDashboard/DashboardModals.tsx
@@ -94,6 +94,7 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
       move_in_date_preferred: tenantProfile?.voorkeur_verhuisdatum ? convertFromISODate(tenantProfile.voorkeur_verhuisdatum) : undefined,
       move_in_date_earliest: tenantProfile?.vroegste_verhuisdatum ? convertFromISODate(tenantProfile.vroegste_verhuisdatum) : undefined,
       availability_flexible: tenantProfile?.beschikbaarheid_flexibel_timing || tenantProfile?.beschikbaarheid_flexibel || false,
+      parking_required: tenantProfile?.woningvoorkeur?.parkeren || false,
       lease_duration_preference: tenantProfile?.huurcontract_voorkeur || undefined,
       storage_kelder: tenantProfile?.opslag_kelder || false,
       storage_zolder: tenantProfile?.opslag_zolder || false,

--- a/src/components/modals/EnhancedProfileUpdateModal.tsx
+++ b/src/components/modals/EnhancedProfileUpdateModal.tsx
@@ -96,6 +96,7 @@ export const EnhancedProfileUpdateModal = ({ isOpen, onClose, onProfileComplete,
       move_in_date_earliest: undefined,
       availability_flexible: false,
       lease_duration_preference: undefined,
+      parking_required: false,
       
       // Storage preferences
       storage_kelder: false,

--- a/src/components/modals/profileSchema.ts
+++ b/src/components/modals/profileSchema.ts
@@ -79,6 +79,7 @@ export const profileSchema = z.object({
   move_in_date_earliest: z.string().optional(),
   availability_flexible: z.boolean().default(false),
   lease_duration_preference: z.enum(['6_maanden', '1_jaar', '2_jaar', 'langer', 'flexibel']).optional(),
+  parking_required: z.boolean().default(false),
   
   // Storage preferences
   storage_kelder: z.boolean().default(false),

--- a/src/utils/profileDataMapper.ts
+++ b/src/utils/profileDataMapper.ts
@@ -63,6 +63,7 @@ export function mapProfileFormToDutch(data: ProfileFormData): any {
     vroegste_verhuisdatum: data.move_in_date_earliest ? convertDateFormat(data.move_in_date_earliest) : undefined,
     beschikbaarheid_flexibel: data.availability_flexible,
     huurcontract_voorkeur: data.lease_duration_preference,
+    parkeren_vereist: data.parking_required,
     
     // Storage preferences
     opslag_kelder: data.storage_kelder,


### PR DESCRIPTION
## Summary
- extend profile schema with `parking_required`
- default parking requirement to `false` in profile update modal
- map `parking_required` to `parkeren_vereist`
- load parking preference from dashboard data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889f9dd9d00832bbe10df5bad5fe037