### PR TITLE
Add parking requirement field mappings

### DIFF
--- a/src/components/HuurderDashboard/DashboardModals.tsx
+++ b/src/components/HuurderDashboard/DashboardModals.tsx
@@ -95,6 +95,7 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
       move_in_date_earliest: tenantProfile?.vroegste_verhuisdatum ? convertFromISODate(tenantProfile.vroegste_verhuisdatum) : undefined,
       availability_flexible: tenantProfile?.beschikbaarheid_flexibel_timing || tenantProfile?.beschikbaarheid_flexibel || false,
       lease_duration_preference: tenantProfile?.huurcontract_voorkeur || undefined,
+      parking_required: tenantProfile?.parkeren_vereist || false,
       storage_kelder: tenantProfile?.opslag_kelder || false,
       storage_zolder: tenantProfile?.opslag_zolder || false,
       storage_berging: tenantProfile?.opslag_berging || false,

--- a/src/components/modals/EnhancedProfileUpdateModal.tsx
+++ b/src/components/modals/EnhancedProfileUpdateModal.tsx
@@ -96,7 +96,8 @@ export const EnhancedProfileUpdateModal = ({ isOpen, onClose, onProfileComplete,
       move_in_date_earliest: undefined,
       availability_flexible: false,
       lease_duration_preference: undefined,
-      
+      parking_required: false,
+
       // Storage preferences
       storage_kelder: false,
       storage_zolder: false,

--- a/src/components/modals/profileSchema.ts
+++ b/src/components/modals/profileSchema.ts
@@ -79,7 +79,9 @@ export const profileSchema = z.object({
   move_in_date_earliest: z.string().optional(),
   availability_flexible: z.boolean().default(false),
   lease_duration_preference: z.enum(['6_maanden', '1_jaar', '2_jaar', 'langer', 'flexibel']).optional(),
-  
+
+  parking_required: z.boolean().default(false),
+
   // Storage preferences
   storage_kelder: z.boolean().default(false),
   storage_zolder: z.boolean().default(false),

--- a/src/utils/profileDataMapper.ts
+++ b/src/utils/profileDataMapper.ts
@@ -22,6 +22,7 @@ export function mapProfileFormToDutch(data: ProfileFormData): any {
     beroep: data.profession,
     werkgever: data.employer,
     dienstverband: data.employment_status,
+    contract_type: data.work_contract_type,
     inkomen: data.monthly_income,
     // Add fields expected by validation
     maandinkomen: data.monthly_income,
@@ -34,6 +35,7 @@ export function mapProfileFormToDutch(data: ProfileFormData): any {
     extra_inkomen: data.extra_income,
     extra_inkomen_beschrijving: data.extra_income_description,
     thuiswerken: data.work_from_home,
+    inkomensbewijs_beschikbaar: data.inkomensbewijs_beschikbaar,
     nationaliteit: data.nationality,
     geslacht: data.sex,
     burgerlijke_staat: data.marital_status,
@@ -63,6 +65,7 @@ export function mapProfileFormToDutch(data: ProfileFormData): any {
     vroegste_verhuisdatum: data.move_in_date_earliest ? convertDateFormat(data.move_in_date_earliest) : undefined,
     beschikbaarheid_flexibel: data.availability_flexible,
     huurcontract_voorkeur: data.lease_duration_preference,
+    parkeren_vereist: data.parking_required,
     
     // Storage preferences
     opslag_kelder: data.storage_kelder,


### PR DESCRIPTION
## Summary
- add `parking_required` to profile schema
- add default `parking_required` value to the enhanced profile modal
- map parking/contract/income proof fields in `mapProfileFormToDutch`
- include parking requirement when loading profile data

## Testing
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore", unexpected any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889fca8dd98832baa16ead2b92723a1