### PR TITLE
Add min_budget validation and update UI

### DIFF
--- a/src/components/modals/EnhancedProfileSteps/Step4Housing.tsx
+++ b/src/components/modals/EnhancedProfileSteps/Step4Housing.tsx
@@ -104,13 +104,13 @@ export default function Step4Housing() {
 
       <div className="grid md:grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label htmlFor="min_budget">Minimum budget</Label>
+          <Label htmlFor="min_budget">Minimum budget *</Label>
           <div className="relative">
             <Euro className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
             <Input
               id="min_budget"
               type="number"
-              {...register('min_budget', { valueAsNumber: true })}
+              {...register('min_budget', { valueAsNumber: true, required: true })}
               placeholder="1200"
               className="pl-10"
             />

--- a/src/components/modals/stepValidationSchemas.ts
+++ b/src/components/modals/stepValidationSchemas.ts
@@ -64,6 +64,7 @@ export const step3Schema = z.object({});
 export const step4Schema = z.object({
   preferred_city: z.array(LocationDataSchema).min(1, 'Minimaal één voorkeursstad is verplicht'),
   preferred_property_type: z.enum(['appartement', 'huis', 'studio', 'kamer', 'penthouse'], { required_error: 'Woningtype is verplicht' }),
+  min_budget: z.number().min(1, 'Minimum budget is verplicht'),
   max_budget: z.number().min(1, "Budget moet groter dan 0 zijn"),
 });
 
@@ -106,6 +107,7 @@ export const getFieldLabel = (fieldName: string): string => {
     monthly_income: 'Maandinkomen',
     preferred_city: 'Voorkeursstad',
     preferred_property_type: 'Woningtype',
+    min_budget: 'Minimum budget',
     max_budget: 'Maximaal budget',
     bio: 'Bio',
     motivation: 'Motivatie',


### PR DESCRIPTION
## Summary
- add `min_budget` to the step4 validation schema
- register the new budget field as required in the Step4 form
- show an asterisk on the "Minimum budget" label

## Testing
- `pnpm lint` *(fails: many existing lint errors)*
- `pnpm test` *(fails: no test script defined)*

------
https://chatgpt.com/codex/tasks/task_e_688a8a8a7dbc832bb2c00f38c5beb429