### PR TITLE
Refactor dashboard layout

### DIFF
--- a/src/components/HuurderDashboard/DashboardModals.tsx
+++ b/src/components/HuurderDashboard/DashboardModals.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { EnhancedProfileUpdateModal } from '@/components/modals/EnhancedProfileUpdateModal';
-import DocumentUploadModal from '@/components/modals/DocumentUploadModal';
-import { PaymentModal } from '@/components/PaymentModal';
-import { ProfileFormData } from '@/components/modals/profileSchema';
-import { convertFromISODate } from '@/utils/dateUtils';
+import React, { useMemo } from "react";
+import { EnhancedProfileUpdateModal } from "@/components/modals/EnhancedProfileUpdateModal";
+import DocumentUploadModal from "@/components/modals/DocumentUploadModal";
+import { PaymentModal } from "@/components/PaymentModal";
+import { ProfileFormData } from "@/components/modals/profileSchema";
+import { convertFromISODate } from "@/utils/dateUtils";
 
 interface DashboardModalsProps {
   showProfileModal: boolean;
@@ -19,6 +19,120 @@ interface DashboardModalsProps {
   tenantProfile?: any;
 }
 
+const getInitialFormData = (
+  tenantProfile?: any,
+  user?: any,
+): Partial<ProfileFormData> | undefined => {
+  if (!tenantProfile && !user) return undefined;
+
+  const nameParts = user?.name?.split(" ") || [""];
+  const firstNameFromUser = nameParts[0] || "";
+  const lastNameFromUser =
+    nameParts.length > 1 ? nameParts.slice(1).join(" ") : "";
+
+  return {
+    first_name: tenantProfile?.firstName || firstNameFromUser || "",
+    last_name: tenantProfile?.lastName || lastNameFromUser || "",
+    date_of_birth: tenantProfile?.dateOfBirth
+      ? convertFromISODate(tenantProfile.dateOfBirth)
+      : "",
+    phone: tenantProfile?.phone || "",
+    sex: tenantProfile?.personalInfo?.sex || "zeg_ik_liever_niet",
+    nationality: tenantProfile?.personalInfo?.nationality || "Nederlandse",
+    marital_status: tenantProfile?.personalInfo?.maritalStatus || "single",
+    has_children: tenantProfile?.hasChildren || false,
+    number_of_children: tenantProfile?.numberOfChildren || 0,
+    children_ages: tenantProfile?.childrenAges || [],
+
+    profession:
+      tenantProfile?.profession ||
+      tenantProfile?.workAndIncome?.profession ||
+      "",
+    employer: tenantProfile?.workAndIncome?.employer || "",
+    employment_status:
+      tenantProfile?.workAndIncome?.employmentStatus || "full-time",
+    work_contract_type: tenantProfile?.workAndIncome?.contractType || "",
+    monthly_income:
+      tenantProfile?.workAndIncome?.monthlyIncome ??
+      (tenantProfile?.income || 0),
+    inkomensbewijs_beschikbaar:
+      tenantProfile?.incomeProofAvailable ??
+      (tenantProfile?.workAndIncome?.incomeProofAvailable || false),
+    work_from_home: tenantProfile?.workAndIncome?.workFromHome || false,
+    extra_income: tenantProfile?.extraIncome || 0,
+    extra_income_description: tenantProfile?.extraIncomeDescription || "",
+
+    has_partner: tenantProfile?.hasPartner || false,
+    partner_name: tenantProfile?.partnerName || "",
+    partner_profession: tenantProfile?.partnerProfession || "",
+    partner_employment_status: tenantProfile?.partnerEmploymentStatus || "",
+    partner_monthly_income: tenantProfile?.partnerMonthlyIncome || 0,
+    borgsteller_beschikbaar: tenantProfile?.guarantorAvailable || false,
+    borgsteller_naam: tenantProfile?.guarantorName || "",
+    borgsteller_relatie: tenantProfile?.guarantorRelationship || "",
+    borgsteller_telefoon: tenantProfile?.guarantorPhone || "",
+    borgsteller_inkomen: tenantProfile?.guarantorIncome || 0,
+
+    preferred_city: tenantProfile?.preferredLocations || [],
+    preferred_property_type:
+      tenantProfile?.housingPreferences?.propertyType || "appartement",
+    preferred_bedrooms: tenantProfile?.housingPreferences?.bedrooms,
+    furnished_preference:
+      tenantProfile?.housingPreferences?.furnishedPreference,
+    min_budget:
+      tenantProfile?.preferences?.minBudget ??
+      tenantProfile?.housingPreferences?.minBudget ??
+      0,
+    max_budget:
+      tenantProfile?.maxRent ??
+      tenantProfile?.preferences?.maxBudget ??
+      tenantProfile?.housingPreferences?.maxBudget ??
+      1000,
+    min_kamers:
+      tenantProfile?.minRooms ??
+      tenantProfile?.housingPreferences?.minRooms ??
+      1,
+    max_kamers:
+      tenantProfile?.maxRooms ??
+      tenantProfile?.housingPreferences?.maxRooms ??
+      5,
+
+    move_in_date_preferred: tenantProfile?.preferredMoveDate
+      ? convertFromISODate(tenantProfile.preferredMoveDate)
+      : tenantProfile?.moveInDatePreferred
+        ? convertFromISODate(tenantProfile.moveInDatePreferred)
+        : undefined,
+    move_in_date_earliest: tenantProfile?.earliestMoveDate
+      ? convertFromISODate(tenantProfile.earliestMoveDate)
+      : tenantProfile?.moveInDateEarliest
+        ? convertFromISODate(tenantProfile.moveInDateEarliest)
+        : undefined,
+    availability_flexible: tenantProfile?.availabilityFlexible || false,
+    parking_required:
+      tenantProfile?.housingPreferences?.parkingRequired || false,
+    lease_duration_preference:
+      tenantProfile?.housingPreferences?.leaseDurationPreference,
+    storage_kelder: tenantProfile?.storageKelder || false,
+    storage_zolder: tenantProfile?.storageZolder || false,
+    storage_berging: tenantProfile?.storageBerging || false,
+    storage_garage: tenantProfile?.storageGarage || false,
+    storage_schuur: tenantProfile?.storageSchuur || false,
+
+    hasPets: tenantProfile?.hasPets || false,
+    pet_details: tenantProfile?.petDetails || "",
+    smokes: tenantProfile?.smokes || false,
+    smoking_details: tenantProfile?.smokingDetails || "",
+
+    references_available: tenantProfile?.referencesAvailable || false,
+    rental_history_years: tenantProfile?.rentalHistoryYears || 0,
+    reason_for_moving: tenantProfile?.reasonForMoving || "",
+
+    profilePictureUrl: tenantProfile?.profilePicture || "",
+    bio: tenantProfile?.bio || "",
+    motivation: tenantProfile?.motivation || "",
+  };
+};
+
 export const DashboardModals: React.FC<DashboardModalsProps> = ({
   showProfileModal,
   showDocumentModal,
@@ -32,99 +146,10 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
   user,
   tenantProfile,
 }) => {
-  // Convert tenant profile data to form format for editing
-  const getInitialFormData = (user?: any): Partial<ProfileFormData> | undefined => {
-    if (!tenantProfile && !user) return undefined;
-
-
-    // Properly handle multi-word last names like "Soto Garcia"
-    const nameParts = user?.name?.split(' ') || [''];
-    const firstNameFromUser = nameParts[0] || '';
-    const lastNameFromUser = nameParts.length > 1 ? nameParts.slice(1).join(' ') : '';
-
-    return {
-      // Step 1: Personal Info - FIXED: Added date conversion
-      first_name: tenantProfile?.firstName || firstNameFromUser || '',
-      last_name: tenantProfile?.lastName || lastNameFromUser || '',
-      date_of_birth: tenantProfile?.dateOfBirth ? convertFromISODate(tenantProfile.dateOfBirth) : '',
-      phone: tenantProfile?.phone || '',
-      sex: tenantProfile?.personalInfo?.sex || 'zeg_ik_liever_niet',
-      nationality: tenantProfile?.personalInfo?.nationality || 'Nederlandse',
-      marital_status: tenantProfile?.personalInfo?.maritalStatus || 'single',
-      has_children: tenantProfile?.hasChildren || false,
-      number_of_children: tenantProfile?.numberOfChildren || 0,
-      children_ages: tenantProfile?.childrenAges || [],
-      
-      // Step 2: Employment - FIXED: Corrected field mappings
-      profession: tenantProfile?.profession || tenantProfile?.workAndIncome?.profession || '',
-      employer: tenantProfile?.workAndIncome?.employer || '',
-      employment_status: tenantProfile?.workAndIncome?.employmentStatus || 'full-time',
-      work_contract_type: tenantProfile?.workAndIncome?.contractType || '',
-      monthly_income: tenantProfile?.workAndIncome?.monthlyIncome ?? (tenantProfile?.income || 0),
-      inkomensbewijs_beschikbaar: tenantProfile?.incomeProofAvailable ?? (tenantProfile?.workAndIncome?.incomeProofAvailable || false),
-      work_from_home: tenantProfile?.workAndIncome?.workFromHome || false,
-      extra_income: tenantProfile?.extraIncome || 0,
-      extra_income_description: tenantProfile?.extraIncomeDescription || '',
-      
-      // Step 3: Household - FIXED: Corrected field mappings
-      has_partner: tenantProfile?.hasPartner || false,
-      partner_name: tenantProfile?.partnerName || '',
-      partner_profession: tenantProfile?.partnerProfession || '',
-      partner_employment_status: tenantProfile?.partnerEmploymentStatus || '',
-      partner_monthly_income: tenantProfile?.partnerMonthlyIncome || 0,
-      borgsteller_beschikbaar: tenantProfile?.guarantorAvailable || false,
-      borgsteller_naam: tenantProfile?.guarantorName || '',
-      borgsteller_relatie: tenantProfile?.guarantorRelationship || '',
-      borgsteller_telefoon: tenantProfile?.guarantorPhone || '',
-      borgsteller_inkomen: tenantProfile?.guarantorIncome || 0,
-      
-      // Step 4: Housing Preferences (consolidated)
-      preferred_city: tenantProfile?.preferredLocations || [],
-      preferred_property_type: tenantProfile?.housingPreferences?.propertyType || 'appartement',
-      preferred_bedrooms: tenantProfile?.housingPreferences?.bedrooms,
-      furnished_preference: tenantProfile?.housingPreferences?.furnishedPreference,
-      min_budget: tenantProfile?.preferences?.minBudget ?? tenantProfile?.housingPreferences?.minBudget ?? 0,
-      max_budget: tenantProfile?.maxRent ?? tenantProfile?.preferences?.maxBudget ?? tenantProfile?.housingPreferences?.maxBudget ?? 1000,
-      min_kamers: tenantProfile?.minRooms ?? tenantProfile?.housingPreferences?.minRooms ?? 1,
-      max_kamers: tenantProfile?.maxRooms ?? tenantProfile?.housingPreferences?.maxRooms ?? 5,
-      
-      // Timing & Storage (consolidated) - FIXED: Added date conversion
-      move_in_date_preferred: tenantProfile?.preferredMoveDate
-        ? convertFromISODate(tenantProfile.preferredMoveDate)
-        : tenantProfile?.moveInDatePreferred
-          ? convertFromISODate(tenantProfile.moveInDatePreferred)
-          : undefined,
-      move_in_date_earliest: tenantProfile?.earliestMoveDate
-        ? convertFromISODate(tenantProfile.earliestMoveDate)
-        : tenantProfile?.moveInDateEarliest
-          ? convertFromISODate(tenantProfile.moveInDateEarliest)
-          : undefined,
-      availability_flexible: tenantProfile?.availabilityFlexible || false,
-      parking_required: tenantProfile?.housingPreferences?.parkingRequired || false,
-      lease_duration_preference: tenantProfile?.housingPreferences?.leaseDurationPreference,
-      storage_kelder: tenantProfile?.storageKelder || false,
-      storage_zolder: tenantProfile?.storageZolder || false,
-      storage_berging: tenantProfile?.storageBerging || false,
-      storage_garage: tenantProfile?.storageGarage || false,
-      storage_schuur: tenantProfile?.storageSchuur || false,
-      
-      // Lifestyle (consolidated) - FIXED: Corrected field mappings
-      hasPets: tenantProfile?.hasPets || false,
-      pet_details: tenantProfile?.petDetails || '',
-      smokes: tenantProfile?.smokes || false,
-      smoking_details: tenantProfile?.smokingDetails || '',
-      
-      // References & History
-      references_available: tenantProfile?.referencesAvailable || false,
-      rental_history_years: tenantProfile?.rentalHistoryYears || 0,
-      reason_for_moving: tenantProfile?.reasonForMoving || '',
-      
-      // Profile & Motivation - FIXED: Corrected field mappings
-      profilePictureUrl: tenantProfile?.profilePicture || '',
-      bio: tenantProfile?.bio || '',
-      motivation: tenantProfile?.motivation || '',
-    };
-  };
+  const initialData = useMemo(
+    () => getInitialFormData(tenantProfile, user),
+    [tenantProfile, user],
+  );
   return (
     <>
       {/* Profile Creation Modal */}
@@ -132,7 +157,7 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
         isOpen={showProfileModal}
         onClose={() => setShowProfileModal(false)}
         onProfileComplete={onProfileComplete}
-        initialData={getInitialFormData(user)}
+        initialData={initialData}
       />
 
       {/* Document Upload Modal */}

--- a/src/components/HuurderDashboard/ProfileActions.tsx
+++ b/src/components/HuurderDashboard/ProfileActions.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { User as UserIcon, FileText, Home } from "lucide-react";
+
+interface ProfileActionsProps {
+  onShowProfileModal: () => void;
+  onShowDocumentModal: () => void;
+  onNavigateSearch: () => void;
+  onNavigateHelp: () => void;
+}
+
+export const ProfileActions: React.FC<ProfileActionsProps> = ({
+  onShowProfileModal,
+  onShowDocumentModal,
+  onNavigateSearch,
+  onNavigateHelp,
+}) => (
+  <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-3 sm:p-4 lg:p-6 mt-8">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <Button
+        variant="default"
+        size="sm"
+        className="w-full justify-center text-xs sm:text-sm lg:text-base h-12 sm:h-9 lg:h-10"
+        onClick={onShowProfileModal}
+      >
+        <UserIcon className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
+        <span className="hidden lg:inline">Profiel bewerken</span>
+        <span className="lg:hidden">Profiel</span>
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full justify-center text-xs sm:text-sm lg:text-base h-12 sm:h-9 lg:h-10"
+        onClick={onShowDocumentModal}
+      >
+        <FileText className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
+        <span className="hidden lg:inline">Documenten beheren</span>
+        <span className="lg:hidden">Documenten</span>
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full justify-center text-xs sm:text-sm lg:text-base h-12 sm:h-9 lg:h-10"
+        onClick={onNavigateSearch}
+      >
+        <Home className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
+        <span className="hidden lg:inline">Woningen zoeken</span>
+        <span className="lg:hidden">Zoeken</span>
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full justify-center text-xs sm:text-sm lg:text-base h-12 sm:h-9 lg:h-10"
+        onClick={onNavigateHelp}
+      >
+        <span className="hidden lg:inline">Help & Support</span>
+        <span className="lg:hidden">Help</span>
+      </Button>
+    </div>
+  </div>
+);
+
+export default ProfileActions;

--- a/src/components/modals/DocumentUploadModal.tsx
+++ b/src/components/modals/DocumentUploadModal.tsx
@@ -1,28 +1,28 @@
-import { useState, useCallback, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
-import { Badge } from '@/components/ui/badge';
-import { useToast } from '@/hooks/use-toast';
-import { useAuthStore } from '@/store/authStore';
+import { useState, useCallback, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useAuthStore } from "@/store/authStore";
 import { documentService } from "@/services/DocumentService";
-import { 
-  DocumentType, 
-  DOCUMENT_TYPE_LABELS, 
+import {
+  DocumentType,
+  DOCUMENT_TYPE_LABELS,
   DOCUMENT_TYPE_DESCRIPTIONS,
   DOCUMENT_REQUIREMENTS,
-  FILE_VALIDATION_RULES 
-} from '@/types/documents';
-import { 
-  Upload, 
-  FileText, 
-  CheckCircle, 
-  XCircle, 
-  AlertCircle, 
+  FILE_VALIDATION_RULES,
+} from "@/types/documents";
+import {
+  Upload,
+  FileText,
+  CheckCircle,
+  XCircle,
+  AlertCircle,
   Eye,
-  Trash2
-} from 'lucide-react';
-import { BaseModal, BaseModalActions, useModalState } from './BaseModal';
+  Trash2,
+} from "lucide-react";
+import { BaseModal, BaseModalActions, useModalState } from "./BaseModal";
 
 interface DocumentUploadModalProps {
   open: boolean;
@@ -36,14 +36,56 @@ interface UploadedDocument {
   fileName: string;
   fileSize: number;
   type: DocumentType;
-  status: 'ready' | 'uploading' | 'success' | 'error';
+  status: "ready" | "uploading" | "success" | "error";
   uploadProgress: number;
   uploadedAt: string;
   error?: string;
   result?: any;
 }
 
-const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentUploadModalProps) => {
+const documentTypes = [
+  {
+    type: "identiteit" as DocumentType,
+    label: "Identiteitsbewijs",
+    description: "Paspoort, ID-kaart of rijbewijs",
+    icon: FileText,
+    required: true,
+  },
+  {
+    type: "inkomen" as DocumentType,
+    label: "Inkomensbewijs",
+    description: "Laatste 3 maanden loonstroken of jaaropgave",
+    icon: FileText,
+    required: true,
+  },
+  {
+    type: "arbeidscontract" as DocumentType,
+    label: "Arbeidscontract",
+    description: "Huidig arbeidscontract",
+    icon: FileText,
+    required: false,
+  },
+  {
+    type: "referentie" as DocumentType,
+    label: "Referentie",
+    description: "Referentie van vorige verhuurder",
+    icon: FileText,
+    required: false,
+  },
+  {
+    type: "uittreksel_bkr" as DocumentType,
+    label: "BKR Uittreksel",
+    description: "Recent BKR-uittreksel (niet ouder dan 3 maanden)",
+    icon: FileText,
+    required: false,
+  },
+];
+
+const DocumentUploadModal = ({
+  open,
+  onOpenChange,
+  onUploadComplete,
+}: DocumentUploadModalProps) => {
   const { user } = useAuthStore();
   const { toast } = useToast();
   const [documents, setDocuments] = useState<UploadedDocument[]>([]);
@@ -58,70 +100,37 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
 
   const loadExistingDocuments = async () => {
     if (!user?.id) return;
-    
+
     try {
       const result = await documentService.getDocuments(user.id);
       if (result.success && result.data) {
         setExistingDocuments(result.data);
       }
     } catch (error) {
-      console.error('Error loading existing documents:', error);
+      console.error("Error loading existing documents:", error);
     }
   };
-
-  const documentTypes = [
-    {
-      type: 'identiteit' as DocumentType,
-      label: 'Identiteitsbewijs',
-      description: 'Paspoort, ID-kaart of rijbewijs',
-      icon: FileText,
-      required: true,
-    },
-    {
-      type: 'inkomen' as DocumentType,
-      label: 'Inkomensbewijs',
-      description: 'Laatste 3 maanden loonstroken of jaaropgave',
-      icon: FileText,
-      required: true,
-    },
-    {
-      type: 'arbeidscontract' as DocumentType,
-      label: 'Arbeidscontract',
-      description: 'Huidig arbeidscontract',
-      icon: FileText,
-      required: false,
-    },
-    {
-      type: 'referentie' as DocumentType,
-      label: 'Referentie',
-      description: 'Referentie van vorige verhuurder',
-      icon: FileText,
-      required: false,
-    },
-    {
-      type: 'uittreksel_bkr' as DocumentType,
-      label: 'BKR Uittreksel',
-      description: 'Recent BKR-uittreksel (niet ouder dan 3 maanden)',
-      icon: FileText,
-      required: false,
-    },
-  ];
 
   const validateFile = (file: File): { isValid: boolean; error?: string } => {
     // Check file size (10MB limit)
     if (file.size > 10 * 1024 * 1024) {
       return {
         isValid: false,
-        error: `Bestand is te groot. Maximum grootte is 10MB.`
+        error: `Bestand is te groot. Maximum grootte is 10MB.`,
       };
     }
 
     // Check file type
-    const allowedTypes = ['application/pdf', 'image/jpeg', 'image/png', 'image/jpg'];
+    const allowedTypes = [
+      "application/pdf",
+      "image/jpeg",
+      "image/png",
+      "image/jpg",
+    ];
     if (!allowedTypes.includes(file.type)) {
       return {
         isValid: false,
-        error: 'Alleen PDF, JPG en PNG bestanden zijn toegestaan.'
+        error: "Alleen PDF, JPG en PNG bestanden zijn toegestaan.",
       };
     }
 
@@ -135,18 +144,20 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
       toast({
         title: "Ongeldig bestand",
         description: validation.error,
-        variant: "destructive"
+        variant: "destructive",
       });
       return;
     }
 
     // Check if this document type is already uploaded
-    const existingDoc = documents.find(doc => doc.type === documentType && doc.status !== 'error');
+    const existingDoc = documents.find(
+      (doc) => doc.type === documentType && doc.status !== "error",
+    );
     if (existingDoc) {
       toast({
         title: "Document al geüpload",
-        description: `Je hebt al een ${documentTypes.find(t => t.type === documentType)?.label} geüpload.`,
-        variant: "destructive"
+        description: `Je hebt al een ${documentTypes.find((t) => t.type === documentType)?.label} geüpload.`,
+        variant: "destructive",
       });
       return;
     }
@@ -158,143 +169,161 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
       fileName: file.name,
       fileSize: file.size,
       type: documentType,
-      status: 'uploading',
+      status: "uploading",
       uploadProgress: 10,
       uploadedAt: new Date().toISOString(),
     };
 
     // Add document to state immediately with uploading status
-    setDocuments(prev => [...prev, newDocument]);
-    
+    setDocuments((prev) => [...prev, newDocument]);
+
     toast({
       title: "Document uploaden gestart",
-      description: `${documentTypes.find(t => t.type === documentType)?.label} wordt geüpload...`
+      description: `${documentTypes.find((t) => t.type === documentType)?.label} wordt geüpload...`,
     });
 
     // Start upload immediately
     try {
       const uploadedDoc = await uploadDocument(newDocument);
-      
+
       toast({
         title: "Document geüpload",
-        description: `${documentTypes.find(t => t.type === documentType)?.label} is succesvol geüpload.`
+        description: `${documentTypes.find((t) => t.type === documentType)?.label} is succesvol geüpload.`,
       });
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Upload mislukt';
+      const errorMessage =
+        error instanceof Error ? error.message : "Upload mislukt";
       toast({
-        title: 'Upload mislukt',
+        title: "Upload mislukt",
         description: `${file.name}: ${errorMessage}`,
-        variant: 'destructive'
+        variant: "destructive",
       });
     }
   };
 
   const removeDocument = (documentId: string) => {
-    setDocuments(prev => prev.filter(doc => doc.id !== documentId));
+    setDocuments((prev) => prev.filter((doc) => doc.id !== documentId));
     toast({
       title: "Document verwijderd",
-      description: "Het document is verwijderd uit je upload."
+      description: "Het document is verwijderd uit je upload.",
     });
   };
 
-  const getStatusIcon = (status: UploadedDocument['status']) => {
+  const getStatusIcon = (status: UploadedDocument["status"]) => {
     switch (status) {
-      case 'ready':
+      case "ready":
         return <FileText className="w-4 h-4 text-gray-500" />;
-      case 'uploading':
+      case "uploading":
         return <Upload className="w-4 h-4 text-blue-500 animate-pulse" />;
-      case 'success':
+      case "success":
         return <CheckCircle className="w-4 h-4 text-green-500" />;
-      case 'error':
+      case "error":
         return <XCircle className="w-4 h-4 text-red-500" />;
       default:
         return <FileText className="w-4 h-4 text-gray-500" />;
     }
   };
 
-  const getStatusText = (status: UploadedDocument['status']) => {
+  const getStatusText = (status: UploadedDocument["status"]) => {
     switch (status) {
-      case 'ready':
-        return 'Klaar voor upload';
-      case 'uploading':
-        return 'Uploaden...';
-      case 'success':
-        return 'Geüpload';
-      case 'error':
-        return 'Fout';
+      case "ready":
+        return "Klaar voor upload";
+      case "uploading":
+        return "Uploaden...";
+      case "success":
+        return "Geüpload";
+      case "error":
+        return "Fout";
       default:
-        return 'Onbekend';
+        return "Onbekend";
     }
   };
 
-  const getStatusColor = (status: UploadedDocument['status']) => {
+  const getStatusColor = (status: UploadedDocument["status"]) => {
     switch (status) {
-      case 'ready':
-        return 'bg-gray-100 text-gray-800';
-      case 'uploading':
-        return 'bg-blue-100 text-blue-800';
-      case 'success':
-        return 'bg-green-100 text-green-800';
-      case 'error':
-        return 'bg-red-100 text-red-800';
+      case "ready":
+        return "bg-gray-100 text-gray-800";
+      case "uploading":
+        return "bg-blue-100 text-blue-800";
+      case "success":
+        return "bg-green-100 text-green-800";
+      case "error":
+        return "bg-red-100 text-red-800";
       default:
-        return 'bg-gray-100 text-gray-800';
+        return "bg-gray-100 text-gray-800";
     }
   };
 
   const formatFileSize = (bytes: number) => {
-    if (bytes === 0) return '0 Bytes';
+    if (bytes === 0) return "0 Bytes";
     const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const sizes = ["Bytes", "KB", "MB", "GB"];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
   };
 
   const uploadDocument = async (document: UploadedDocument) => {
     // Update status to uploading
-    setDocuments(prev => prev.map(d => 
-      d.id === document.id ? { ...d, status: 'uploading', uploadProgress: 10 } : d
-    ));
+    setDocuments((prev) =>
+      prev.map((d) =>
+        d.id === document.id
+          ? { ...d, status: "uploading", uploadProgress: 10 }
+          : d,
+      ),
+    );
 
     try {
-      const result = await documentService.uploadDocument(document.file, document.type, user.id);
-      
+      const result = await documentService.uploadDocument(
+        document.file,
+        document.type,
+        user.id,
+      );
+
       if (result.success && result.data) {
-        setDocuments(prev => prev.map(d => 
-          d.id === document.id ? { 
-            ...d, 
-            status: 'success', 
-            uploadProgress: 100,
-            result: result.data
-          } : d
-        ));
+        setDocuments((prev) =>
+          prev.map((d) =>
+            d.id === document.id
+              ? {
+                  ...d,
+                  status: "success",
+                  uploadProgress: 100,
+                  result: result.data,
+                }
+              : d,
+          ),
+        );
         return result.data;
       } else {
-        throw result.error || new Error('Upload mislukt');
+        throw result.error || new Error("Upload mislukt");
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Upload mislukt';
-      
-      setDocuments(prev => prev.map(d => 
-        d.id === document.id ? { 
-          ...d, 
-          status: 'error',
-          error: errorMessage
-        } : d
-      ));
-      
+      const errorMessage =
+        error instanceof Error ? error.message : "Upload mislukt";
+
+      setDocuments((prev) =>
+        prev.map((d) =>
+          d.id === document.id
+            ? {
+                ...d,
+                status: "error",
+                error: errorMessage,
+              }
+            : d,
+        ),
+      );
+
       throw error;
     }
   };
 
   const handleCompleteUpload = async () => {
-    const documentsToUpload = documents.filter(doc => doc.status === 'ready');
-    
+    const documentsToUpload = documents.filter((doc) => doc.status === "ready");
+
     if (documentsToUpload.length === 0) {
       toast({
         title: "Geen documenten om te uploaden",
         description: "Voeg eerst documenten toe voordat je ze uploadt.",
-        variant: "destructive"
+        variant: "destructive",
       });
       return;
     }
@@ -309,21 +338,22 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
         uploadedDocuments.push(uploadedDoc);
       } catch (error) {
         hasErrors = true;
-        const errorMessage = error instanceof Error ? error.message : 'Upload mislukt';
+        const errorMessage =
+          error instanceof Error ? error.message : "Upload mislukt";
         toast({
-          title: 'Upload mislukt',
+          title: "Upload mislukt",
           description: `${doc.fileName}: ${errorMessage}`,
-          variant: 'destructive'
+          variant: "destructive",
         });
       }
     }
 
     if (uploadedDocuments.length > 0) {
       onUploadComplete(uploadedDocuments);
-      
+
       toast({
-        title: 'Documenten geüpload',
-        description: `${uploadedDocuments.length} document(en) zijn succesvol geüpload voor beoordeling.`
+        title: "Documenten geüpload",
+        description: `${uploadedDocuments.length} document(en) zijn succesvol geüpload voor beoordeling.`,
       });
 
       if (!hasErrors) {
@@ -334,15 +364,15 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
     }
   };
 
-  const requiredDocuments = documentTypes.filter(type => type.required);
+  const requiredDocuments = documentTypes.filter((type) => type.required);
   const uploadedRequiredTypes = documents
-    .filter(doc => doc.status !== 'error')
-    .map(doc => doc.type);
-  const hasAllRequired = requiredDocuments.every(type => 
-    uploadedRequiredTypes.includes(type.type)
+    .filter((doc) => doc.status !== "error")
+    .map((doc) => doc.type);
+  const hasAllRequired = requiredDocuments.every((type) =>
+    uploadedRequiredTypes.includes(type.type),
   );
 
-  const readyDocuments = documents.filter(doc => doc.status === 'ready');
+  const readyDocuments = documents.filter((doc) => doc.status === "ready");
 
   return (
     <BaseModal
@@ -354,206 +384,257 @@ const DocumentUploadModal = ({ open, onOpenChange, onUploadComplete }: DocumentU
       maxHeight="max-h-screen"
     >
       <div className="space-y-6">
-          {/* Document Types with Individual Upload */}
-          <div className="grid md:grid-cols-2 gap-4">
-            {documentTypes.map((docType) => {
-              const Icon = docType.icon;
-              
-              // Check both current session uploads and existing documents
-              const hasUploadedInSession = documents.some(doc => 
-                doc.type === docType.type && doc.status !== 'error'
-              );
-              const hasExistingDocument = existingDocuments.some(doc => 
-                doc.type === docType.type
-              );
-              const hasUploaded = hasUploadedInSession || hasExistingDocument;
-              
-              // Get existing document for display
-              const existingDoc = existingDocuments.find(doc => 
-                doc.type === docType.type
-              );
-              
-              return (
-                <Card key={docType.type} className={`${hasUploaded ? 'border-green-200 bg-green-50' : ''}`}>
-                  <CardContent className="pt-4">
-                    <div className="flex items-start space-x-3">
-                      <Icon className="w-5 h-5 mt-1 text-dutch-blue" />
-                      <div className="flex-1">
-                        <div className="flex items-center space-x-2">
-                          <h4 className="font-semibold">{docType.label}</h4>
-                          {docType.required && (
-                            <Badge variant="destructive" className="text-xs">Verplicht</Badge>
-                          )}
-                          {hasUploaded && (
-                            <CheckCircle className="w-4 h-4 text-green-500" />
-                          )}
-                          {existingDoc && (
-                            <Badge 
-                              variant={existingDoc.status === 'goedgekeurd' ? 'default' : 
-                                     existingDoc.status === 'afgewezen' ? 'destructive' : 'secondary'}
-                              className="text-xs"
-                            >
-                              {existingDoc.status === 'wachtend' ? 'In behandeling' :
-                               existingDoc.status === 'goedgekeurd' ? 'Goedgekeurd' :
-                               existingDoc.status === 'afgewezen' ? 'Afgewezen' : existingDoc.status}
-                            </Badge>
-                          )}
-                        </div>
-                        <p className="text-sm text-gray-600 mt-1">{docType.description}</p>
-                        
-                        {/* Show existing document info */}
-                        {existingDoc && (
-                          <div className="mt-2 p-2 bg-blue-50 border border-blue-200 rounded text-sm">
-                            <p className="font-medium text-blue-900">{existingDoc.bestandsnaam}</p>
-                            <p className="text-blue-700">
-                              Geüpload op {new Date(existingDoc.aangemaakt_op).toLocaleDateString('nl-NL')}
-                            </p>
-                          </div>
-                        )}
-                        
-                        {/* Individual Upload Button */}
-                        <div className="mt-3">
-                          <input
-                            type="file"
-                            accept=".pdf,.jpg,.jpeg,.png"
-                            onChange={(e) => {
-                              const file = e.target.files?.[0];
-                              if (file) {
-                                handleFileSelect(file, docType.type);
-                              }
-                              // Reset input
-                              e.target.value = '';
-                            }}
-                            className="hidden"
-                            id={`file-upload-${docType.type}`}
-                            ref={(input) => {
-                              if (input) {
-                                (input as any).docType = docType.type;
-                              }
-                            }}
-                          />
-                          <Button 
-                            variant={hasUploaded ? "outline" : "default"} 
-                            size="sm" 
-                            className="w-full"
-                            disabled={hasUploadedInSession}
-                            onClick={() => {
-                              const input = document.getElementById(`file-upload-${docType.type}`) as HTMLInputElement;
-                              if (input && !hasUploadedInSession) {
-                                input.click();
-                              }
-                            }}
-                          >
-                            <Upload className="w-4 h-4 mr-2" />
-                            {hasExistingDocument ? 'Vervangen' : hasUploadedInSession ? 'Geüpload' : 'Upload'}
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              );
-            })}
-          </div>
+        {/* Document Types with Individual Upload */}
+        <div className="grid md:grid-cols-2 gap-4">
+          {documentTypes.map((docType) => {
+            const Icon = docType.icon;
 
-          {/* Uploaded Documents */}
-          {documents.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle>Geselecteerde Documenten ({documents.length})</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-3">
-                  {documents.map((document) => (
-                    <div
-                      key={document.id}
-                      className="flex items-center space-x-4 p-3 border rounded-lg"
-                    >
-                      <FileText className="w-8 h-8 text-dutch-blue" />
-                      
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center space-x-2">
-                          <h4 className="font-medium truncate">{document.fileName}</h4>
-                          {getStatusIcon(document.status)}
-                        </div>
-                        <div className="flex items-center space-x-4 mt-1">
-                          <span className="text-sm text-gray-500">
-                            {formatFileSize(document.fileSize)}
-                          </span>
-                          <Badge className={`text-xs ${getStatusColor(document.status)}`}>
-                            {getStatusText(document.status)}
-                          </Badge>
-                          <span className="text-sm text-gray-500">
-                            {documentTypes.find(t => t.type === document.type)?.label}
-                          </span>
-                        </div>
-                        
-                        {document.status === 'uploading' && (
-                          <Progress value={document.uploadProgress} className="h-2 mt-2" />
-                        )}
-                        
-                        {document.status === 'error' && document.error && (
-                          <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded text-sm text-red-800">
-                            <AlertCircle className="w-4 h-4 inline mr-1" />
-                            {document.error}
-                          </div>
-                        )}
-                      </div>
-                      
+            // Check both current session uploads and existing documents
+            const hasUploadedInSession = documents.some(
+              (doc) => doc.type === docType.type && doc.status !== "error",
+            );
+            const hasExistingDocument = existingDocuments.some(
+              (doc) => doc.type === docType.type,
+            );
+            const hasUploaded = hasUploadedInSession || hasExistingDocument;
+
+            // Get existing document for display
+            const existingDoc = existingDocuments.find(
+              (doc) => doc.type === docType.type,
+            );
+
+            return (
+              <Card
+                key={docType.type}
+                className={`${hasUploaded ? "border-green-200 bg-green-50" : ""}`}
+              >
+                <CardContent className="pt-4">
+                  <div className="flex items-start space-x-3">
+                    <Icon className="w-5 h-5 mt-1 text-dutch-blue" />
+                    <div className="flex-1">
                       <div className="flex items-center space-x-2">
-                        {document.status !== 'uploading' && (
-                          <Button 
-                            variant="ghost" 
-                            size="sm"
-                            onClick={() => removeDocument(document.id)}
+                        <h4 className="font-semibold">{docType.label}</h4>
+                        {docType.required && (
+                          <Badge variant="destructive" className="text-xs">
+                            Verplicht
+                          </Badge>
+                        )}
+                        {hasUploaded && (
+                          <CheckCircle className="w-4 h-4 text-green-500" />
+                        )}
+                        {existingDoc && (
+                          <Badge
+                            variant={
+                              existingDoc.status === "goedgekeurd"
+                                ? "default"
+                                : existingDoc.status === "afgewezen"
+                                  ? "destructive"
+                                  : "secondary"
+                            }
+                            className="text-xs"
                           >
-                            <Trash2 className="w-4 h-4" />
-                          </Button>
+                            {existingDoc.status === "wachtend"
+                              ? "In behandeling"
+                              : existingDoc.status === "goedgekeurd"
+                                ? "Goedgekeurd"
+                                : existingDoc.status === "afgewezen"
+                                  ? "Afgewezen"
+                                  : existingDoc.status}
+                          </Badge>
                         )}
                       </div>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-          )}
+                      <p className="text-sm text-gray-600 mt-1">
+                        {docType.description}
+                      </p>
 
-          {/* Requirements Check */}
-          {documents.length > 0 && (
-            <Card className={hasAllRequired ? 'border-green-200 bg-green-50' : 'border-orange-200 bg-orange-50'}>
-              <CardContent className="pt-4">
-                <div className="flex items-center space-x-2">
-                  {hasAllRequired ? (
-                    <CheckCircle className="w-5 h-5 text-green-600" />
-                  ) : (
-                    <AlertCircle className="w-5 h-5 text-orange-600" />
-                  )}
-                  <h4 className="font-semibold">
-                    {hasAllRequired ? 'Alle verplichte documenten geselecteerd' : 'Verplichte documenten ontbreken'}
-                  </h4>
-                </div>
-                {!hasAllRequired && (
-                  <p className="text-sm text-orange-700 mt-1">
-                    Selecteer nog: {requiredDocuments
-                      .filter(type => !uploadedRequiredTypes.includes(type.type))
-                      .map(type => type.label)
-                      .join(', ')}
-                  </p>
+                      {/* Show existing document info */}
+                      {existingDoc && (
+                        <div className="mt-2 p-2 bg-blue-50 border border-blue-200 rounded text-sm">
+                          <p className="font-medium text-blue-900">
+                            {existingDoc.bestandsnaam}
+                          </p>
+                          <p className="text-blue-700">
+                            Geüpload op{" "}
+                            {new Date(
+                              existingDoc.aangemaakt_op,
+                            ).toLocaleDateString("nl-NL")}
+                          </p>
+                        </div>
+                      )}
+
+                      {/* Individual Upload Button */}
+                      <div className="mt-3">
+                        <input
+                          type="file"
+                          accept=".pdf,.jpg,.jpeg,.png"
+                          onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (file) {
+                              handleFileSelect(file, docType.type);
+                            }
+                            // Reset input
+                            e.target.value = "";
+                          }}
+                          className="hidden"
+                          id={`file-upload-${docType.type}`}
+                          ref={(input) => {
+                            if (input) {
+                              (input as any).docType = docType.type;
+                            }
+                          }}
+                        />
+                        <Button
+                          variant={hasUploaded ? "outline" : "default"}
+                          size="sm"
+                          className="w-full"
+                          disabled={hasUploadedInSession}
+                          onClick={() => {
+                            const input = document.getElementById(
+                              `file-upload-${docType.type}`,
+                            ) as HTMLInputElement;
+                            if (input && !hasUploadedInSession) {
+                              input.click();
+                            }
+                          }}
+                        >
+                          <Upload className="w-4 h-4 mr-2" />
+                          {hasExistingDocument
+                            ? "Vervangen"
+                            : hasUploadedInSession
+                              ? "Geüpload"
+                              : "Upload"}
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+
+        {/* Uploaded Documents */}
+        {documents.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                Geselecteerde Documenten ({documents.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {documents.map((document) => (
+                  <div
+                    key={document.id}
+                    className="flex items-center space-x-4 p-3 border rounded-lg"
+                  >
+                    <FileText className="w-8 h-8 text-dutch-blue" />
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center space-x-2">
+                        <h4 className="font-medium truncate">
+                          {document.fileName}
+                        </h4>
+                        {getStatusIcon(document.status)}
+                      </div>
+                      <div className="flex items-center space-x-4 mt-1">
+                        <span className="text-sm text-gray-500">
+                          {formatFileSize(document.fileSize)}
+                        </span>
+                        <Badge
+                          className={`text-xs ${getStatusColor(document.status)}`}
+                        >
+                          {getStatusText(document.status)}
+                        </Badge>
+                        <span className="text-sm text-gray-500">
+                          {
+                            documentTypes.find((t) => t.type === document.type)
+                              ?.label
+                          }
+                        </span>
+                      </div>
+
+                      {document.status === "uploading" && (
+                        <Progress
+                          value={document.uploadProgress}
+                          className="h-2 mt-2"
+                        />
+                      )}
+
+                      {document.status === "error" && document.error && (
+                        <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded text-sm text-red-800">
+                          <AlertCircle className="w-4 h-4 inline mr-1" />
+                          {document.error}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex items-center space-x-2">
+                      {document.status !== "uploading" && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => removeDocument(document.id)}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Requirements Check */}
+        {documents.length > 0 && (
+          <Card
+            className={
+              hasAllRequired
+                ? "border-green-200 bg-green-50"
+                : "border-orange-200 bg-orange-50"
+            }
+          >
+            <CardContent className="pt-4">
+              <div className="flex items-center space-x-2">
+                {hasAllRequired ? (
+                  <CheckCircle className="w-5 h-5 text-green-600" />
+                ) : (
+                  <AlertCircle className="w-5 h-5 text-orange-600" />
                 )}
-              </CardContent>
-            </Card>
-          )}
+                <h4 className="font-semibold">
+                  {hasAllRequired
+                    ? "Alle verplichte documenten geselecteerd"
+                    : "Verplichte documenten ontbreken"}
+                </h4>
+              </div>
+              {!hasAllRequired && (
+                <p className="text-sm text-orange-700 mt-1">
+                  Selecteer nog:{" "}
+                  {requiredDocuments
+                    .filter(
+                      (type) => !uploadedRequiredTypes.includes(type.type),
+                    )
+                    .map((type) => type.label)
+                    .join(", ")}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         <BaseModalActions
           cancelAction={{
             label: "Annuleren",
-            onClick: () => onOpenChange(false)
+            onClick: () => onOpenChange(false),
           }}
           primaryAction={{
             label: "Sluiten",
             onClick: () => onOpenChange(false),
-            disabled: documents.filter(doc => doc.status === 'success').length === 0,
-            className: "bg-green-600 hover:bg-green-700"
+            disabled:
+              documents.filter((doc) => doc.status === "success").length === 0,
+            className: "bg-green-600 hover:bg-green-700",
           }}
         />
       </div>


### PR DESCRIPTION
## Summary
- extract profile actions into its own component
- compute profile sections and stats via helper functions
- clean up dashboard modals and document upload modal

## Testing
- `npm run lint` *(fails: Parsing error and many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688b097b0078832bb8bf07fa0551a7bf