### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,8 +23,8 @@ export const Header = ({ onShowSignup }: HeaderProps) => {
 
   return (
     <header className="bg-white shadow-sm border-b">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 sm:py-0">
+        <div className="flex justify-between items-center h-14 sm:h-16">
           <Logo />
 
           <div className="flex items-center space-x-2 sm:space-x-4">

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -8,10 +8,10 @@ interface LogoProps {
 export const Logo = ({ className }: LogoProps) => {
   return (
     <div className={cn("flex items-center", className)}>
-      <img 
-        src="/huurly-logo.svg" 
-        alt="Huurly" 
-        className="h-8 w-auto"
+      <img
+        src="/huurly-logo.svg"
+        alt="Huurly"
+        className="h-6 w-auto sm:h-8"
         onError={(e) => {
           // Fallback to text if SVG fails to load
           const target = e.target as HTMLImageElement;
@@ -19,13 +19,13 @@ export const Logo = ({ className }: LogoProps) => {
           const parent = target.parentElement;
           if (parent && !parent.querySelector('.logo-text')) {
             const textLogo = document.createElement('span');
-            textLogo.className = 'logo-text text-2xl font-bold text-dutch-blue';
+            textLogo.className = 'logo-text text-xl sm:text-2xl font-bold text-dutch-blue';
             textLogo.textContent = 'Huurly';
             parent.appendChild(textLogo);
           }
         }}
       />
-      <span className="ml-2 text-2xl font-bold text-dutch-blue">Huurly</span>
+      <span className="ml-2 text-xl sm:text-2xl font-bold text-dutch-blue">Huurly</span>
     </div>
   );
 };

--- a/src/components/standard/StandardModal.tsx
+++ b/src/components/standard/StandardModal.tsx
@@ -62,11 +62,11 @@ export function StandardModal({
 }: StandardModalProps) {
   // Size classes mapping
   const sizeClasses = {
-    sm: 'max-w-sm',
-    md: 'max-w-md',
-    lg: 'max-w-lg',
-    xl: 'max-w-xl',
-    full: 'max-w-full',
+    sm: 'max-w-[95vw] sm:max-w-sm',
+    md: 'max-w-[95vw] sm:max-w-md',
+    lg: 'max-w-[95vw] sm:max-w-lg',
+    xl: 'max-w-[95vw] sm:max-w-xl',
+    full: 'max-w-[95vw] sm:max-w-full',
   };
   
   return (

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[95vw] sm:max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[95vw] sm:max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/persistent-dialog.tsx
+++ b/src/components/ui/persistent-dialog.tsx
@@ -12,7 +12,7 @@ const PersistentDialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[95vw] sm:max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-4 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- adjust header spacing for small screens
- limit modal max width to `95vw` and reduce padding for mobile devices

## Testing
- `npm run lint -- --fix` *(fails: 6 errors, 289 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688b1520d3c4832bb7315eeedc8664d2