### PR TITLE
Refactor header signup prop usage

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,15 +3,10 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import { LoginForm } from './auth/LoginForm';
-import { MultiStepSignupModal } from './auth/MultiStepSignupModal';
 import { Logo } from './Logo';
 import { useAuthStore } from '@/store/authStore';
 
-interface HeaderProps {
-  onShowSignup?: () => void;
-}
-
-export const Header = ({ onShowSignup }: HeaderProps) => {
+export const Header = () => {
   const [showLogin, setShowLogin] = useState(false);
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -77,7 +77,7 @@ const Index = () => {
 
   return (
     <div className="min-h-screen">
-      <Header onShowSignup={() => setShowSignup(true)} />
+      <Header />
       <Hero onShowSignup={() => setShowSignup(true)} />
       <Features />
       <CTA />


### PR DESCRIPTION
## Summary
- clean up Header component by removing unused signup import and prop
- adjust Index page to match Header changes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Parsing error: Unexpected token :)


------
https://chatgpt.com/codex/tasks/task_e_688e5de7bb34832ba844fdc733405119