### PR TITLE
Remove unused domain module placeholders

### DIFF
--- a/src/domains/application/hooks/index.ts
+++ b/src/domains/application/hooks/index.ts
@@ -1,1 +1,0 @@
-// Application domain hooks will be exported here

--- a/src/domains/application/index.ts
+++ b/src/domains/application/index.ts
@@ -1,5 +1,3 @@
 // Application domain exports
 export * from './components';
 export * from './types';
-export * from './services';
-export * from './store';

--- a/src/domains/application/services/index.ts
+++ b/src/domains/application/services/index.ts
@@ -1,1 +1,0 @@
-// Application domain services will be exported here

--- a/src/domains/application/store/index.ts
+++ b/src/domains/application/store/index.ts
@@ -1,1 +1,0 @@
-// Application domain store will be exported here

--- a/src/domains/payment/hooks/index.ts
+++ b/src/domains/payment/hooks/index.ts
@@ -1,1 +1,0 @@
-// Payment domain hooks will be exported here

--- a/src/domains/payment/services/index.ts
+++ b/src/domains/payment/services/index.ts
@@ -1,1 +1,0 @@
-// Payment domain services will be exported here

--- a/src/domains/payment/store/index.ts
+++ b/src/domains/payment/store/index.ts
@@ -1,1 +1,0 @@
-// Payment domain store will be exported here

--- a/src/domains/property/hooks/index.ts
+++ b/src/domains/property/hooks/index.ts
@@ -1,1 +1,0 @@
-// Property domain hooks will be exported here

--- a/src/domains/property/index.ts
+++ b/src/domains/property/index.ts
@@ -1,6 +1,3 @@
 // Property domain exports
 export * from './components';
 export * from './types';
-export * from './hooks';
-export * from './services';
-export * from './store';

--- a/src/domains/property/services/index.ts
+++ b/src/domains/property/services/index.ts
@@ -1,1 +1,0 @@
-// Property domain services will be exported here

--- a/src/domains/property/store/index.ts
+++ b/src/domains/property/store/index.ts
@@ -1,1 +1,0 @@
-// Property domain store will be exported here

--- a/src/domains/shared/hooks/index.ts
+++ b/src/domains/shared/hooks/index.ts
@@ -1,1 +1,0 @@
-// Shared domain hooks will be exported here

--- a/src/domains/shared/store/index.ts
+++ b/src/domains/shared/store/index.ts
@@ -1,1 +1,0 @@
-// Shared domain store will be exported here

--- a/src/domains/user/hooks/index.ts
+++ b/src/domains/user/hooks/index.ts
@@ -1,1 +1,0 @@
-// User domain hooks will be exported here

--- a/src/domains/user/index.ts
+++ b/src/domains/user/index.ts
@@ -1,6 +1,3 @@
 // User domain exports
 export * from './components';
 export * from './types';
-export * from './hooks';
-export * from './services';
-export * from './store';

--- a/src/domains/user/services/index.ts
+++ b/src/domains/user/services/index.ts
@@ -1,1 +1,0 @@
-// User domain services will be exported here

--- a/src/domains/user/store/index.ts
+++ b/src/domains/user/store/index.ts
@@ -1,1 +1,0 @@
-// User domain store will be exported here


### PR DESCRIPTION
## Summary
- remove empty hooks/services/store modules across domain folders
- update domain barrel files to export only implemented modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 8 errors, 312 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e5df640f8832b8885741e4379f11f