### PR TITLE
chore: hide tenant property search button

### DIFF
--- a/src/components/HuurderDashboard/ProfileActions.tsx
+++ b/src/components/HuurderDashboard/ProfileActions.tsx
@@ -37,16 +37,19 @@ export const ProfileActions: React.FC<ProfileActionsProps> = ({
         <span className="hidden lg:inline">Documenten beheren</span>
         <span className="lg:hidden">Documenten</span>
       </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        className="w-full justify-center text-xs sm:text-sm lg:text-base h-12 sm:h-9 lg:h-10"
-        onClick={onNavigateSearch}
-      >
-        <Home className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
-        <span className="hidden lg:inline">Woningen zoeken</span>
-        <span className="lg:hidden">Zoeken</span>
-      </Button>
+      {/*
+        Temporarily hidden until woning zoeken functionality is reactivated.
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full justify-center text-xs sm:text-sm lg:text-base h-12 sm:h-9 lg:h-10"
+          onClick={onNavigateSearch}
+        >
+          <Home className="w-3 h-3 sm:w-4 sm:h-4 mr-1 sm:mr-2" />
+          <span className="hidden lg:inline">Woningen zoeken</span>
+          <span className="lg:hidden">Zoeken</span>
+        </Button>
+      */}
       <Button
         variant="outline"
         size="sm"


### PR DESCRIPTION
## Summary
- temporarily hide the "Woningen zoeken" button on the tenant dashboard until feature is reactivated

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 321 problems (9 errors, 312 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a463e01ee4832ba1d8527f7a53ae00