### PR TITLE
Add Supabase stats to tenant dashboard

### DIFF
--- a/src/pages/HuurderDashboard.tsx
+++ b/src/pages/HuurderDashboard.tsx
@@ -27,7 +27,7 @@ import { DashboardModals } from "@/components/HuurderDashboard/DashboardModals";
 import ProfileActions from "@/components/HuurderDashboard/ProfileActions";
 import { useToast } from "@/hooks/use-toast";
 import { withAuth } from "@/hocs/withAuth";
-import { User } from "@/types";
+import { User, TenantDashboardData } from "@/types";
 import {
   mapEmploymentStatusLabel,
   mapContractTypeLabel,
@@ -318,7 +318,7 @@ const buildProfileSections = (
   ];
 };
 
-const buildStats = (stats: any, isLoadingStats: boolean) => [
+const buildStats = (stats: TenantDashboardData, isLoadingStats: boolean) => [
   {
     title: "Profiel weergaven",
     value: stats.profileViews,

--- a/src/services/ConsolidatedDashboardService.ts
+++ b/src/services/ConsolidatedDashboardService.ts
@@ -178,7 +178,11 @@ export class ConsolidatedDashboardService extends DatabaseService {
           profileResult,
           userResult,
           subscriptionResult,
-          profilePictureResult
+          profilePictureResult,
+          profileViewsResult,
+          invitationsResult,
+          applicationsResult,
+          acceptedApplicationsResult
         ] = await Promise.allSettled([
           // Get user documents
           supabase
@@ -186,7 +190,7 @@ export class ConsolidatedDashboardService extends DatabaseService {
             .select('*')
             .eq('huurder_id', userId)
             .order('aangemaakt_op', { ascending: false }),
-          
+
           // Get tenant profile
           supabase
             .from('huurders')
@@ -200,16 +204,58 @@ export class ConsolidatedDashboardService extends DatabaseService {
             .select('*')
             .eq('id', userId)
             .maybeSingle(),
-          
+
           // Get active subscription using optimized service
           optimizedSubscriptionService.checkSubscriptionStatus(userId),
-          
+
           // Get profile and cover photo URLs from database
-          this.getPhotoUrls(userId)
+          this.getPhotoUrls(userId),
+
+          // Count profile views
+          supabase
+            .from('profiel_weergaves')
+            .select('id', { count: 'exact', head: true })
+            .eq('huurder_id', userId),
+
+          // Count viewing invitations
+          supabase
+            .from('bezichtiging_verzoeken')
+            .select('id', { count: 'exact', head: true })
+            .eq('huurder_id', userId),
+
+          // Count property applications
+          supabase
+            .from('aanvragen')
+            .select('id', { count: 'exact', head: true })
+            .eq('huurder_id', userId),
+
+          // Count accepted applications
+          supabase
+            .from('aanvragen')
+            .select('id', { count: 'exact', head: true })
+            .eq('huurder_id', userId)
+            .eq('status', 'geaccepteerd')
         ]);
 
         // Process results
-        const stats = { profileViews: 0, invitations: 0, applications: 0, acceptedApplications: 0 };
+        const stats: TenantDashboardData = {
+          profileViews:
+            profileViewsResult.status === 'fulfilled'
+              ? profileViewsResult.value.count ?? 0
+              : 0,
+          invitations:
+            invitationsResult.status === 'fulfilled'
+              ? invitationsResult.value.count ?? 0
+              : 0,
+          applications:
+            applicationsResult.status === 'fulfilled'
+              ? applicationsResult.value.count ?? 0
+              : 0,
+          acceptedApplications:
+            acceptedApplicationsResult.status === 'fulfilled'
+              ? acceptedApplicationsResult.value.count ?? 0
+              : 0
+        };
 
         const rawDocuments = documentsResult.status === 'fulfilled' && documentsResult.value.data
           ? documentsResult.value.data


### PR DESCRIPTION
## Summary
- query Supabase for tenant profile views, invitations, applications, and accepted applications
- map fetched counts into consolidated dashboard stats
- consume typed stats in tenant dashboard without zero fallbacks

## Testing
- `npm test`
- `npm run lint` *(fails: warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68a57c9b8054832b91e931e1a387f356