### PR TITLE
Refresh document list after uploads and add mobile upload page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const HelpSupport = lazy(() => import('./pages/HelpSupport'));
 
 // Mobile modal pages
 const ProfileEditPage = lazy(() => import('./pages/mobile/ProfileEditPage'));
+const DocumentUploadPage = lazy(() => import('./pages/mobile/DocumentUploadPage'));
 
 
 const queryClient = new QueryClient({
@@ -177,6 +178,14 @@ const App = () => (
               element={
                 <ProtectedRoute roles={['huurder']}>
                   <ProfileEditPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/mobile/document-upload"
+              element={
+                <ProtectedRoute roles={['huurder']}>
+                  <DocumentUploadPage />
                 </ProtectedRoute>
               }
             />

--- a/src/components/HuurderDashboard/DashboardModals.tsx
+++ b/src/components/HuurderDashboard/DashboardModals.tsx
@@ -161,13 +161,28 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
         onProfileComplete, // Pass the callback
         returnPath: '/huurder-dashboard'
       });
-      
+
       if (!shouldShowDesktopModal) {
         // On mobile, we navigated to a page, so close the modal state
         setShowProfileModal(false);
       }
     }
   }, [showProfileModal, openModal, initialData, onProfileComplete, setShowProfileModal]);
+
+  // Handle document upload modal routing
+  React.useEffect(() => {
+    if (showDocumentModal) {
+      const shouldShowDesktopModal = openModal('documentUpload', {
+        onUploadComplete: onDocumentUploadComplete,
+        returnPath: '/huurder-dashboard'
+      });
+
+      if (!shouldShowDesktopModal) {
+        // On mobile, we navigated to a page, so close the modal state
+        setShowDocumentModal(false);
+      }
+    }
+  }, [showDocumentModal, openModal, onDocumentUploadComplete, setShowDocumentModal]);
   
   return (
     <>
@@ -181,12 +196,14 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
         />
       )}
 
-      {/* Document Upload Modal */}
-      <DocumentUploadModal
-        open={showDocumentModal}
-        onOpenChange={setShowDocumentModal}
-        onUploadComplete={onDocumentUploadComplete}
-      />
+      {/* Document Upload Modal - Only shown on desktop */}
+      {!isMobile && (
+        <DocumentUploadModal
+          open={showDocumentModal}
+          onOpenChange={setShowDocumentModal}
+          onUploadComplete={onDocumentUploadComplete}
+        />
+      )}
 
       {/* Persistent Payment Modal - cannot be closed without payment */}
       <PaymentModal

--- a/src/components/HuurderDashboard/QuickActionsSection.tsx
+++ b/src/components/HuurderDashboard/QuickActionsSection.tsx
@@ -1,7 +1,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import { User, Bell, Settings, Loader2 } from "lucide-react";
+import { User, Bell, Settings, Loader2, FileText } from "lucide-react";
 
 interface QuickActionsSectionProps {
   hasProfile: boolean;
@@ -91,16 +91,24 @@ export const QuickActionsSection = ({
           </Button>
         </div>
         
-        <Button 
-          className="bg-orange-500 hover:bg-orange-600 text-white font-semibold text-xs sm:text-sm py-2 sm:py-3 px-3 sm:px-4 h-auto flex-col items-center justify-center min-h-[70px] sm:min-h-[80px] shadow-md" 
+        <Button
+          className="bg-orange-500 hover:bg-orange-600 text-white font-semibold text-xs sm:text-sm py-2 sm:py-3 px-3 sm:px-4 h-auto flex-col items-center justify-center min-h-[70px] sm:min-h-[80px] shadow-md"
           onClick={onShowProfileModal}
         >
           <User className="mb-1 sm:mb-2 h-4 w-4 sm:h-5 sm:w-5" />
           <span className="text-center">Profiel Bewerken</span>
         </Button>
-        
-        <Button 
-          className="bg-blue-600 text-white hover:bg-blue-500 font-semibold text-xs sm:text-sm py-2 sm:py-3 px-3 sm:px-4 h-auto flex-col items-center justify-center min-h-[70px] sm:min-h-[80px] border border-blue-500 shadow-md" 
+
+        <Button
+          className="bg-blue-600 text-white hover:bg-blue-500 font-semibold text-xs sm:text-sm py-2 sm:py-3 px-3 sm:px-4 h-auto flex-col items-center justify-center min-h-[70px] sm:min-h-[80px] border border-blue-500 shadow-md"
+          onClick={onShowDocumentModal}
+        >
+          <FileText className="mb-1 sm:mb-2 h-4 w-4 sm:h-5 sm:w-5" />
+          <span className="text-center">Documenten</span>
+        </Button>
+
+        <Button
+          className="bg-blue-600 text-white hover:bg-blue-500 font-semibold text-xs sm:text-sm py-2 sm:py-3 px-3 sm:px-4 h-auto flex-col items-center justify-center min-h-[70px] sm:min-h-[80px] border border-blue-500 shadow-md"
           onClick={onReportIssue}
         >
           <Bell className="mb-1 sm:mb-2 h-4 w-4 sm:h-5 sm:w-5" />

--- a/src/components/modals/DocumentUploadModal.tsx
+++ b/src/components/modals/DocumentUploadModal.tsx
@@ -292,6 +292,8 @@ const DocumentUploadModal = ({
               : d,
           ),
         );
+        // Refresh existing documents after successful upload
+        await loadExistingDocuments();
         return result.data;
       } else {
         throw result.error || new Error("Upload mislukt");
@@ -355,6 +357,9 @@ const DocumentUploadModal = ({
         title: "Documenten geüpload",
         description: `${uploadedDocuments.length} document(en) zijn succesvol geüpload voor beoordeling.`,
       });
+
+      // Refresh existing documents after batch upload
+      await loadExistingDocuments();
 
       if (!hasErrors) {
         // Only close modal if no errors occurred

--- a/src/pages/mobile/DocumentUploadPage.tsx
+++ b/src/pages/mobile/DocumentUploadPage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import DocumentUploadModal from '@/components/modals/DocumentUploadModal';
+import { useModalRouter } from '@/hooks/useModalRouter';
+
+const DocumentUploadPage: React.FC = () => {
+  const { closeModal, getModalData } = useModalRouter();
+  const modalData = getModalData();
+  const onUploadComplete = modalData?.onUploadComplete;
+
+  return (
+    <DocumentUploadModal
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) {
+          closeModal();
+        }
+      }}
+      onUploadComplete={onUploadComplete || (() => {})}
+    />
+  );
+};
+
+export default DocumentUploadPage;


### PR DESCRIPTION
## Summary
- Refresh existing document list after each upload and after batch uploads
- Route document upload via modal router and expose mobile document upload page
- Link document uploads from quick actions and add mobile route

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a57ca12ddc832b80dd6ce35b133f0a