### PR TITLE
feat: add mobile payment routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const HelpSupport = lazy(() => import('./pages/HelpSupport'));
 
 // Mobile modal pages
 const ProfileEditPage = lazy(() => import('./pages/mobile/ProfileEditPage'));
+const PaymentPage = lazy(() => import('./pages/mobile/PaymentPage'));
 
 
 const queryClient = new QueryClient({
@@ -177,6 +178,14 @@ const App = () => (
               element={
                 <ProtectedRoute roles={['huurder']}>
                   <ProfileEditPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/mobile/payment"
+              element={
+                <ProtectedRoute roles={['huurder']}>
+                  <PaymentPage />
                 </ProtectedRoute>
               }
             />

--- a/src/components/HuurderDashboard/DashboardModals.tsx
+++ b/src/components/HuurderDashboard/DashboardModals.tsx
@@ -151,7 +151,7 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
   );
   
   const { openModal, isMobile } = useModalRouter();
-  
+
   // Handle profile modal opening with route-based approach
   React.useEffect(() => {
     if (showProfileModal) {
@@ -168,6 +168,16 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
       }
     }
   }, [showProfileModal, openModal, initialData, onProfileComplete, setShowProfileModal]);
+
+  // Handle payment modal opening with route-based approach
+  React.useEffect(() => {
+    if (showPaymentModal) {
+      const shouldShowDesktopModal = openModal('payment');
+      if (!shouldShowDesktopModal) {
+        setShowPaymentModal(false);
+      }
+    }
+  }, [showPaymentModal, openModal, setShowPaymentModal]);
   
   return (
     <>
@@ -188,12 +198,14 @@ export const DashboardModals: React.FC<DashboardModalsProps> = ({
         onUploadComplete={onDocumentUploadComplete}
       />
 
-      {/* Persistent Payment Modal - cannot be closed without payment */}
-      <PaymentModal
-        isOpen={showPaymentModal}
-        onClose={(open) => setShowPaymentModal(open)}
-        persistent={true}
-      />
+      {/* Persistent Payment Modal - Only shown on desktop */}
+      {!isMobile && (
+        <PaymentModal
+          isOpen={showPaymentModal}
+          onClose={(open) => setShowPaymentModal(open)}
+          persistent={true}
+        />
+      )}
     </>
   );
 };

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -17,7 +17,8 @@ import { logStripeDebugInfo } from "@/utils/stripe-debug";
 
 interface PaymentModalProps {
   isOpen: boolean;
-  onClose: (show: boolean) => void;
+  /** Callback when the modal's open state changes */
+  onClose?: (show: boolean) => void;
   /** Display the modal without a close button and ignore outside clicks */
   persistent?: boolean;
 }
@@ -110,7 +111,10 @@ const PaymentModal = ({
   const Content = PersistentDialogContent;
 
   return (
-    <Dialog open={isOpen} onOpenChange={persistent ? undefined : (open) => onClose(open)}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={persistent ? undefined : (open) => onClose?.(open)}
+    >
       <Content className="max-w-[95vw] sm:max-w-md mx-4 sm:mx-auto" aria-describedby="payment-modal-description">
         <DialogHeader>
           <div className="flex items-center justify-between">
@@ -122,7 +126,7 @@ const PaymentModal = ({
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => onClose(false)}
+                onClick={() => onClose?.(false)}
                 className="h-6 w-6 rounded-full"
               >
                 <X className="h-4 w-4" />

--- a/src/pages/HuurderDashboard.tsx
+++ b/src/pages/HuurderDashboard.tsx
@@ -529,9 +529,15 @@ const HuurderDashboard: React.FC<HuurderDashboardProps> = () => {
 
             {/* 2. Profile Actions Section */}
             <ProfileActions
-              onShowProfileModal={() => setShowProfileModal(true)}
-              onShowDocumentModal={() => setShowDocumentModal(true)}
-              onNavigateSearch={() => navigate("/property-search")}
+              onShowProfileModal={() =>
+                isSubscribed ? setShowProfileModal(true) : setShowPaymentModal(true)
+              }
+              onShowDocumentModal={() =>
+                isSubscribed ? setShowDocumentModal(true) : setShowPaymentModal(true)
+              }
+              onNavigateSearch={() =>
+                isSubscribed ? navigate("/property-search") : setShowPaymentModal(true)
+              }
               onNavigateHelp={() => navigate("/help-support")}
             />
 
@@ -539,12 +545,16 @@ const HuurderDashboard: React.FC<HuurderDashboardProps> = () => {
             <ProfileOverview
               sections={profileSections}
               title="Profiel Overzicht"
-              onEdit={() => setShowProfileModal(true)}
+              onEdit={() =>
+                isSubscribed ? setShowProfileModal(true) : setShowPaymentModal(true)
+              }
               isCreating={!tenantProfile}
             />
             <DocumentsSection
               userDocuments={userDocuments}
-              onShowDocumentModal={() => setShowDocumentModal(true)}
+              onShowDocumentModal={() =>
+                isSubscribed ? setShowDocumentModal(true) : setShowPaymentModal(true)
+              }
               title="Mijn Documenten"
               emptyStateTitle="Nog geen documenten geüpload."
               emptyStateDescription="Klik op 'Document Uploaden' om te beginnen."

--- a/src/pages/mobile/PaymentPage.tsx
+++ b/src/pages/mobile/PaymentPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PaymentModal from '@/components/PaymentModal';
+import { useModalRouter } from '@/hooks/useModalRouter';
+
+const PaymentPage: React.FC = () => {
+  const { closeModal } = useModalRouter();
+
+  return (
+    <PaymentModal
+      isOpen={true}
+      onClose={(open) => {
+        if (!open) closeModal();
+      }}
+    />
+  );
+};
+
+export default PaymentPage;


### PR DESCRIPTION
## Summary
- trigger modal router for payment flows and only render payment modal on desktop
- add standalone mobile payment page
- gate dashboard actions behind subscription checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57ca25f5c832b8da2e373b5f10726