### PR TITLE
fix: resolve type errors and clean exports

### DIFF
--- a/src/components/modals/EnhancedProfileUpdateModal.tsx
+++ b/src/components/modals/EnhancedProfileUpdateModal.tsx
@@ -182,7 +182,7 @@ const EnhancedProfileUpdateModal = ({ isOpen, onClose, onProfileComplete, initia
       console.log('🔥 EnhancedProfileUpdateModal.onSubmit - Parsed data:', parsedData);
     } catch (validationError) {
       if (validationError instanceof z.ZodError) {
-        const fieldErrors = validationError.flatten().fieldErrors;
+        const fieldErrors = validationError.flatten().fieldErrors as Record<string, string[]>;
         const errorMessages = Object.entries(fieldErrors)
           .map(([fieldName, errors]) => `${fieldName}: ${errors?.join(', ')}`)
           .join('; ');

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 
 import { cn } from "@/lib/utils";

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -272,11 +272,12 @@ const ChartLegend = RechartsPrimitive.Legend
 
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<"div"> &
-    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-      hideIcon?: boolean
-      nameKey?: string
-    }
+  React.ComponentProps<"div"> & {
+    payload?: any[]
+    verticalAlign?: RechartsPrimitive.LegendProps["verticalAlign"]
+    hideIcon?: boolean
+    nameKey?: string
+  }
 >(
   (
     { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
@@ -284,7 +285,7 @@ const ChartLegendContent = React.forwardRef<
   ) => {
     const { config } = useChart()
 
-    if (!payload?.length) {
+    if (!payload || payload.length === 0) {
       return null
     }
 
@@ -297,7 +298,7 @@ const ChartLegendContent = React.forwardRef<
           className
         )}
       >
-        {payload.map((item: any) => {
+        {payload.map((item: RechartsPrimitive.LegendPayload) => {
           const key = `${nameKey || item.dataKey || "value"}`
           const itemConfig = getPayloadConfigFromPayload(config, item, key)
 

--- a/src/domains/shared/index.ts
+++ b/src/domains/shared/index.ts
@@ -1,3 +1,3 @@
 // Shared domain exports
 export * from './types';
-export * from './services';
+export { BaseService } from './services';

--- a/src/domains/shared/services/BaseService.ts
+++ b/src/domains/shared/services/BaseService.ts
@@ -1,5 +1,14 @@
 import { logger } from '../../../lib/logger';
-import { ServiceResponse, ServiceContext, ServiceError } from '../types/api';
+import { ServiceResponse, ServiceContext, ServiceError, ValidationSchema, BaseValidationError } from '../types/api';
+
+interface FieldValidationRules {
+  type?: 'string' | 'number' | 'boolean' | 'object';
+  minLength?: number;
+  maxLength?: number;
+  pattern?: RegExp;
+  patternMessage?: string;
+  custom?: (value: any) => boolean | string;
+}
 
 /**
  * Enhanced Base Service with improved architecture
@@ -69,15 +78,15 @@ export abstract class BaseService {
     queryFn: () => Promise<{ data: T | null; error: any }>,
     context: ServiceContext
   ): Promise<ServiceResponse<T>> {
-    return this.executeOperation(async () => {
+    return this.executeOperation<T | null>(async () => {
       const { data, error } = await queryFn();
-      
+
       if (error) {
         throw this.createDatabaseError(error);
       }
-      
+
       return data;
-    }, context);
+    }, context) as Promise<ServiceResponse<T>>;
   }
 
   /**
@@ -102,7 +111,7 @@ export abstract class BaseService {
     }
 
     // Validate field rules
-    for (const [field, rules] of Object.entries(schema.fields || {})) {
+    for (const [field, rules] of Object.entries(schema.fields || {}) as [string, FieldValidationRules][]) {
       const value = sanitizedData[field as keyof T];
       if (this.hasValue(value)) {
         const fieldErrors = this.validateField(field, value, rules);
@@ -304,33 +313,4 @@ export abstract class BaseService {
   private generateOperationId(): string {
     return `${this.domain}_${this.serviceName}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
   }
-}
-
-/**
- * Validation schema interface
- */
-export interface ValidationSchema<T> {
-  required?: (keyof T)[];
-  fields?: Partial<Record<keyof T, FieldValidationRules>>;
-}
-
-/**
- * Field validation rules
- */
-export interface FieldValidationRules {
-  type?: 'string' | 'number' | 'boolean' | 'object';
-  minLength?: number;
-  maxLength?: number;
-  pattern?: RegExp;
-  patternMessage?: string;
-  custom?: (value: any) => boolean | string;
-}
-
-/**
- * Validation error interface
- */
-export interface BaseValidationError {
-  field: string;
-  message: string;
-  code: string;
 }

--- a/src/hooks/useProfileWarnings.ts
+++ b/src/hooks/useProfileWarnings.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { useHuurder } from '@/hooks/useHuurder';
+import type { TenantProfile } from '@/types';
 
 interface ProfileWarningsState {
   profileWarningShown: boolean;
@@ -57,8 +58,8 @@ export const useProfileWarnings = () => {
     const isSameDay = warningsState.lastShownDate === today;
 
     // Check profile completeness
-    const requiredFields = ['profession', 'income', 'age', 'preferredLocations', 'maxRent'];
-    const isProfileComplete = requiredFields.every(field => tenantProfile[field] != null);
+    const requiredFields = ['profession', 'income', 'age', 'preferredLocations', 'maxRent'] as const;
+    const isProfileComplete = requiredFields.every(field => tenantProfile[field as keyof TenantProfile] != null);
     
     // Check documents
     const hasRequiredDocuments = userDocuments.length >= 3;

--- a/src/hooks/useValidatedMultiStepForm.ts
+++ b/src/hooks/useValidatedMultiStepForm.ts
@@ -42,7 +42,7 @@ export function useValidatedMultiStepForm(
       return [];
     } catch (error) {
       if (error instanceof z.ZodError) {
-        const validationErrors = error.errors.map(err => ({
+        const validationErrors = error.issues.map((err: z.ZodIssue) => ({
           field: err.path.join('.'),
           message: err.message,
           label: getFieldLabel(err.path[0] as string)

--- a/src/lib/auth/authService.ts
+++ b/src/lib/auth/authService.ts
@@ -34,7 +34,7 @@ export class AuthService {
       // Validate email format
       const emailValidation = emailSchema.safeParse(data.email);
       if (!emailValidation.success) {
-        const error = new Error(emailValidation.error.errors[0]?.message || 'Ongeldig e-mailadres') as AuthError;
+        const error = new Error(emailValidation.error.issues[0]?.message || 'Ongeldig e-mailadres') as AuthError;
         error.status = 400;
         return { user: null, error };
       }
@@ -42,7 +42,7 @@ export class AuthService {
       // Validate password strength
       const passwordValidation = passwordSchema.safeParse(data.password);
       if (!passwordValidation.success) {
-        const error = new Error(passwordValidation.error.errors[0]?.message || 'Wachtwoord voldoet niet aan de eisen') as AuthError;
+        const error = new Error(passwordValidation.error.issues[0]?.message || 'Wachtwoord voldoet niet aan de eisen') as AuthError;
         error.status = 400;
         return { user: null, error };
       }
@@ -116,7 +116,7 @@ export class AuthService {
       });
 
       if (!validationResult.success) {
-        const errorMessage = validationResult.error.errors[0]?.message || 'Ongeldige Wachtwoord - Probeer Opnieuw';
+        const errorMessage = validationResult.error.issues[0]?.message || 'Ongeldige Wachtwoord - Probeer Opnieuw';
         const error = new Error(errorMessage) as AuthError;
         error.status = 400;
         return { user: null, error };
@@ -320,7 +320,7 @@ export class AuthService {
       if (!passwordValidation.success) {
         return {
           success: false,
-          message: passwordValidation.error.errors[0]?.message || 'Wachtwoord voldoet niet aan de eisen'
+          message: passwordValidation.error.issues[0]?.message || 'Wachtwoord voldoet niet aan de eisen'
         };
       }
 

--- a/src/pages/HuurderDashboard.tsx
+++ b/src/pages/HuurderDashboard.tsx
@@ -18,10 +18,6 @@ import MessageInbox from "@/components/HuurderDashboard/MessageInbox";
 import NotificationPanel from "@/components/HuurderDashboard/NotificationPanel";
 import DashboardOverview from "@/components/HuurderDashboard/DashboardOverview";
 import {
-  Eye,
-  Calendar,
-  FileText,
-  CheckCircle,
   User as UserIcon,
   Briefcase,
   Home,
@@ -323,38 +319,7 @@ const buildProfileSections = (
   ];
 };
 
-const buildStats = (stats: any, isLoadingStats: boolean) => [
-  {
-    title: "Profiel weergaven",
-    value: stats.profileViews,
-    icon: Eye,
-    color: "blue-600",
-    loading: isLoadingStats,
-  },
-  {
-    title: "Uitnodigingen",
-    value: stats.invitations,
-    icon: Calendar,
-    color: "green-600",
-    loading: isLoadingStats,
-  },
-  {
-    title: "Aanvragen",
-    value: stats.applications,
-    icon: FileText,
-    color: "orange-600",
-    loading: isLoadingStats,
-  },
-  {
-    title: "Geaccepteerd",
-    value: stats.acceptedApplications,
-    icon: CheckCircle,
-    color: "emerald-600",
-    loading: isLoadingStats,
-  },
-];
-
-const HuurderDashboard: React.FC<HuurderDashboardProps> = () => {
+  const HuurderDashboard: React.FC<HuurderDashboardProps> = () => {
   const huurderHook = useHuurder();
   const matchingHook = useMatching();
   
@@ -362,9 +327,8 @@ const HuurderDashboard: React.FC<HuurderDashboardProps> = () => {
     user,
     userDocuments,
     isLoading: isHuurderLoading,
-    stats,
-    isLoadingStats,
-    profilePictureUrl,
+      stats,
+      profilePictureUrl,
     tenantProfile,
     subscription,
     refresh,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -125,7 +125,6 @@ const Index = () => {
             }, 1000);
           }
         }}
-        userName={user?.name}
       />
       
       <PaymentSuccessModal

--- a/src/pages/PropertySearch.tsx
+++ b/src/pages/PropertySearch.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Search, MapPin, Euro, Home, ArrowLeft, Heart, Eye } from 'lucide-react';
+import { Search, MapPin, Euro, Home, ArrowLeft, Heart, Eye, Bed } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { DashboardHeader } from '@/components/dashboard';
 import { useAuthStore } from '@/store/authStore';
@@ -187,10 +187,10 @@ const PropertySearch: React.FC = () => {
     });
   };
 
-  const handleViewProperty = () => {
+  const handleViewProperty = (propertyId: string) => {
     toast({
       title: 'Eigenschap bekijken',
-      description: 'Functionaliteit voor het bekijken van eigenschappen wordt binnenkort toegevoegd.',
+      description: `Functionaliteit voor het bekijken van eigenschap ${propertyId} wordt binnenkort toegevoegd.`,
     });
   };
 
@@ -216,10 +216,10 @@ const PropertySearch: React.FC = () => {
             email: user.email,
             isActive: true,
             createdAt: user.createdAt,
-            hasPayment: false,
-            subscriptionEndDate: null,
-            profilePictureUrl: null
-          }}
+              hasPayment: false,
+              subscriptionEndDate: undefined,
+              profilePictureUrl: undefined
+            }}
           onSettings={() => {}}
           onLogout={() => navigate('/login')}
         />

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -79,10 +79,10 @@ const ResetPassword: React.FC = () => {
     try {
       // Validate password strength
       const passwordValidation = passwordSchema.safeParse(password);
-      if (!passwordValidation.success) {
-        setError(passwordValidation.error.errors[0]?.message || 'Wachtwoord voldoet niet aan de eisen');
-        return;
-      }
+        if (!passwordValidation.success) {
+          setError(passwordValidation.error.issues[0]?.message || 'Wachtwoord voldoet niet aan de eisen');
+          return;
+        }
 
       // Update password directly using Supabase
       const { error: updateError } = await supabase.auth.updateUser({

--- a/src/pages/mobile/ProfileEditPage.tsx
+++ b/src/pages/mobile/ProfileEditPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -83,7 +83,7 @@ const ProfileEditPage: React.FC = () => {
       preferred_property_type: 'appartement',
       preferred_bedrooms: undefined,
       furnished_preference: undefined,
-      min_budget: undefined,
+        min_budget: 0,
       max_budget: 1000,
       min_kamers: undefined,
       max_kamers: undefined,
@@ -149,7 +149,7 @@ const ProfileEditPage: React.FC = () => {
   };
 
   const methods = useForm<ProfileFormData>({
-    resolver: zodResolver(profileSchema),
+      resolver: zodResolver(profileSchema) as any,
     defaultValues: getDefaultValues(),
   });
 
@@ -181,14 +181,14 @@ const ProfileEditPage: React.FC = () => {
     <Step7ProfileMotivation key="step7" />,
   ];
 
-  const onSubmit = async (data: ProfileFormData) => {
+  const onSubmit: SubmitHandler<ProfileFormData> = async (data) => {
     // Validate entire form before submission
     try {
       profileSchema.parse(data);
     } catch (validationError) {
-      if (validationError instanceof z.ZodError) {
-        const errorMessages = validationError.errors.map(err => err.message).join(', ');
-        toast({
+        if (validationError instanceof z.ZodError) {
+          const errorMessages = validationError.issues.map(err => err.message).join(', ');
+          toast({
           title: 'Validatie Fout',
           description: `Er ontbreken nog verplichte velden: ${errorMessages}`,
           variant: 'destructive',

--- a/src/services/ApplicationService.ts
+++ b/src/services/ApplicationService.ts
@@ -91,7 +91,7 @@ export class ApplicationService extends DatabaseService {
     });
   }
 
-  async getApplications(userId?: string): Promise<DatabaseResponse<Application[]>> {
+  async getApplications(): Promise<DatabaseResponse<Application[]>> {
     const currentUserId = await this.getCurrentUserId();
     if (!currentUserId) {
       return {

--- a/src/services/AuditLogService.ts
+++ b/src/services/AuditLogService.ts
@@ -1,5 +1,5 @@
 
-import { DatabaseService, DatabaseResponse, PaginationOptions, SortOptions } from '../lib/database.ts';
+import { DatabaseService, DatabaseResponse } from '../lib/database.ts';
 
 export interface AuditLogFilters {
   userId?: string;

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -247,18 +247,18 @@ export abstract class BaseService extends DatabaseService {
     operationName: string,
     resourceId?: string
   ): Promise<ServiceResponse<T>> {
-    return this.executeServiceOperation(async () => {
+    return this.executeServiceOperation<T | null>(async () => {
       const { data, error } = await query();
-      
+
       if (error) {
         throw this.handleDatabaseError(error);
       }
-      
+
       return data;
     }, {
       operation: operationName,
       resourceId
-    });
+    }) as Promise<ServiceResponse<T>>;
   }
 
   /**
@@ -310,7 +310,7 @@ export abstract class BaseService extends DatabaseService {
     try {
       const currentUserId = userId || await this.getCurrentUserId();
       if (currentUserId) {
-        await this.createAuditLog(action, table, recordId, oldData, newData);
+        await this.createAuditLog(action, table, recordId ?? undefined, oldData, newData);
       }
     } catch (error) {
       // Log audit failures but don't throw - audit should not break main operations

--- a/src/services/DashboardDataService.ts
+++ b/src/services/DashboardDataService.ts
@@ -2,7 +2,6 @@
 import { supabase } from '../integrations/supabase/client';
 import { DatabaseService, DatabaseResponse } from '../lib/database';
 import { ErrorHandler } from '../lib/errors';
-import { logger } from '../lib/logger';
 import { Property } from '@/types';
 
 export interface DashboardData {

--- a/src/services/DashboardService.ts
+++ b/src/services/DashboardService.ts
@@ -2,7 +2,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import { DatabaseService, DatabaseResponse } from '../lib/database';
 import { ErrorHandler } from '../lib/errors';
-import { logger } from '../lib/logger';
 
 export interface DashboardStats {
   totalUsers: number;

--- a/src/services/DocumentService.ts
+++ b/src/services/DocumentService.ts
@@ -20,17 +20,17 @@ export class DocumentService extends BaseService {
     documentType: DocumentType,
     userId: string
   ): Promise<ServiceResponse<Document>> {
-    return this.executeAuthenticatedOperation(async (currentUserId) => {
-      // Validate user authorization
-      if (currentUserId !== userId) {
-        throw new PermissionError('Alleen eigen documenten kunnen worden geüpload');
-      }
+      return this.executeAuthenticatedOperation(async (_currentUserId) => {
+        // Validate user authorization
+        if (_currentUserId !== userId) {
+          throw new PermissionError('Alleen eigen documenten kunnen worden geüpload');
+        }
 
       // Validate user role
-      const { data: gebruiker } = await supabase
-        .from('gebruikers')
-        .select('rol')
-        .eq('id', currentUserId)
+        const { data: gebruiker } = await supabase
+          .from('gebruikers')
+          .select('rol')
+          .eq('id', _currentUserId)
         .single();
 
       if (!gebruiker || !isTenant(gebruiker.rol)) {
@@ -160,11 +160,11 @@ export class DocumentService extends BaseService {
     }, 'reviewDocument', documentId, { status, notes });
   }
 
-  async deleteDocument(documentId: string, userId: string): Promise<ServiceResponse<boolean>> {
-    return this.executeAuthenticatedOperation(async (userId) => {
-      if (currentUserId !== userId) {
-        throw new PermissionError('Alleen eigen documenten kunnen worden verwijderd');
-      }
+    async deleteDocument(documentId: string, userId: string): Promise<ServiceResponse<boolean>> {
+      return this.executeAuthenticatedOperation(async (currentUserId) => {
+        if (currentUserId !== userId) {
+          throw new PermissionError('Alleen eigen documenten kunnen worden verwijderd');
+        }
 
       const { data: document } = await supabase
         .from('documenten')
@@ -181,7 +181,7 @@ export class DocumentService extends BaseService {
         .from('documenten')
         .delete()
         .eq('id', documentId)
-        .eq('huurder_id', userId);
+          .eq('huurder_id', userId);
 
       if (error) {
         throw this.handleDatabaseError(error);
@@ -190,11 +190,11 @@ export class DocumentService extends BaseService {
       await this.createStandardAuditLog('DOCUMENT_DELETE', 'documenten', documentId, null);
 
       return true;
-    }, 'deleteDocument', documentId, { userId });
-  }
+      }, 'deleteDocument', documentId, { userId });
+    }
 
-  async getDocumentUrl(documentId: string, userId: string): Promise<ServiceResponse<string>> {
-    return this.executeAuthenticatedOperation(async (currentUserId) => {
+    async getDocumentUrl(documentId: string, userId: string): Promise<ServiceResponse<string>> {
+      return this.executeAuthenticatedOperation(async (_currentUserId) => {
       const { data: document, error } = await supabase
         .from('documenten')
         .select('bestand_url')

--- a/src/services/FavoritesService.ts
+++ b/src/services/FavoritesService.ts
@@ -1,6 +1,5 @@
 import { supabase } from '../integrations/supabase/client';
 import { DatabaseService, DatabaseResponse } from '../lib/database';
-import { logger } from '../lib/logger';
 
 export class FavoritesService extends DatabaseService {
   async listSavedProfiles(landlordId: string): Promise<DatabaseResponse<string[]>> {

--- a/src/services/MatchingService.ts
+++ b/src/services/MatchingService.ts
@@ -313,9 +313,9 @@ export class MatchingService {
       'studio': ['appartement', 'loft']
     };
 
-    if (similarTypes[tenantType]?.includes(propertyType)) {
-      return 0.8; // Good match
-    }
+      if (similarTypes[tenantType as keyof typeof similarTypes]?.includes(propertyType)) {
+        return 0.8; // Good match
+      }
 
     return 0.3; // Low match
   }

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1,7 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import { DatabaseService, DatabaseResponse } from '@/lib/database';
 import { ErrorHandler } from '@/lib/errors';
-import { logger } from '@/lib/logger';
 import { notificationService } from './NotificationService';
 
 export interface Message {

--- a/src/services/OptimizedSubscriptionService.ts
+++ b/src/services/OptimizedSubscriptionService.ts
@@ -113,27 +113,20 @@ class OptimizedSubscriptionService extends DatabaseService {
   async getSubscriptionExpiration(userId: string): Promise<DatabaseResponse<{ expiresAt: string | null; daysRemaining: number | null }>> {
     return this.executeQuery(async () => {
       const result = await this.checkSubscriptionStatus(userId);
-      
+
+      let expiresAt: string | null = null;
+      let daysRemaining: number | null = null;
+
       if (result.success && result.data?.expiresAt) {
-        const expiresAt = result.data.expiresAt;
+        expiresAt = result.data.expiresAt;
         const expirationDate = new Date(expiresAt);
         const today = new Date();
-        const daysRemaining = Math.ceil((expirationDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
-        
-        return {
-          data: {
-            expiresAt,
-            daysRemaining: daysRemaining > 0 ? daysRemaining : 0
-          },
-          error: null
-        };
+        const diff = Math.ceil((expirationDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+        daysRemaining = diff > 0 ? diff : 0;
       }
 
       return {
-        data: {
-          expiresAt: null,
-          daysRemaining: null
-        },
+        data: { expiresAt, daysRemaining },
         error: null
       };
     });
@@ -145,7 +138,7 @@ class OptimizedSubscriptionService extends DatabaseService {
   async isSubscriptionExpiringSoon(userId: string): Promise<boolean> {
     try {
       const result = await this.getSubscriptionExpiration(userId);
-      if (result.success && result.data?.daysRemaining !== null) {
+      if (result.success && result.data && result.data.daysRemaining !== null) {
         return result.data.daysRemaining <= 14;
       }
       return false;

--- a/src/services/PropertyService.ts
+++ b/src/services/PropertyService.ts
@@ -151,10 +151,8 @@ export class PropertyService extends BaseService {
   }
 
   async getProperties(landlordId?: string): Promise<ServiceResponse<Property[]>> {
-    return this.executeAuthenticatedOperation(async (currentUserId) => {
-      const targetUserId = landlordId || currentUserId;
-
-      let query = supabase.from('woningen').select('*').order('aangemaakt_op', { ascending: false });
+      return this.executeAuthenticatedOperation(async (currentUserId) => {
+        let query = supabase.from('woningen').select('*').order('aangemaakt_op', { ascending: false });
 
       if (landlordId) {
         query = query.eq('verhuurder_id', landlordId);

--- a/src/services/payment/PricingService.ts
+++ b/src/services/payment/PricingService.ts
@@ -57,7 +57,7 @@ export class PricingService extends DatabaseService {
         created_at: new Date().toISOString()
       };
 
-      await this.createAuditLog('APPROVAL_REQUEST', 'approval_requests', null, null, requestData);
+        await this.createAuditLog('APPROVAL_REQUEST', 'approval_requests', undefined, undefined, requestData);
 
       return { data: requestData, error: null };
     });

--- a/src/services/payment/StripeCheckoutService.ts
+++ b/src/services/payment/StripeCheckoutService.ts
@@ -3,7 +3,6 @@ import { supabase } from '../../integrations/supabase/client';
 import { getStripe, SUBSCRIPTION_PLANS } from '../../lib/stripe-config';
 import { DatabaseService, DatabaseResponse } from '../../lib/database';
 import { ErrorHandler } from '../../lib/errors';
-import { paymentRecordService } from './PaymentRecordService';
 import { logger } from '../../lib/logger';
 
 export class StripeCheckoutService extends DatabaseService {

--- a/src/services/payment/SubscriptionService.ts
+++ b/src/services/payment/SubscriptionService.ts
@@ -1,8 +1,6 @@
 
 import { supabase } from '../../integrations/supabase/client.ts';
 import { DatabaseService, DatabaseResponse } from '../../lib/database.ts';
-import { ErrorHandler } from '../../lib/errors.ts';
-import { PaymentRecord } from './PaymentRecordService';
 
 export interface SubscriptionStatus {
   hasActiveSubscription: boolean;

--- a/src/store/auth/authActions.ts
+++ b/src/store/auth/authActions.ts
@@ -1,6 +1,4 @@
 
-import { supabase } from '@/integrations/supabase/client';
-import { authService } from '@/lib/auth';
 import { logger } from '@/lib/logger';
 import { User } from '@/types';
 import { optimizedSubscriptionService } from '@/services/OptimizedSubscriptionService';


### PR DESCRIPTION
## Summary
- fix recharts legend typings and handle payload generics
- streamline shared domain exports and base service validation helpers
- align forms and services with zod/react-hook-form and remove unused imports

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a844973ba8832ba121c824ff431c41