### PR TITLE
feat: wire up profile form save

### DIFF
--- a/src/components/modals/EnhancedProfileUpdateModal.tsx
+++ b/src/components/modals/EnhancedProfileUpdateModal.tsx
@@ -261,6 +261,7 @@ const EnhancedProfileUpdateModal = ({ isOpen, onClose, onProfileComplete, initia
               onNext={nextStep}
               validateCurrentStep={validateCurrentStep}
               isSubmitting={methods.formState.isSubmitting}
+              onSaveClick={methods.handleSubmit(onSubmit)}
             />
 
           </form>

--- a/src/components/modals/ProfileFormNavigation.tsx
+++ b/src/components/modals/ProfileFormNavigation.tsx
@@ -39,6 +39,17 @@ const ProfileFormNavigation: React.FC<ProfileFormNavigationProps> = ({
     }
   };
 
+  const handleSave = () => {
+    const errors = validateCurrentStep ? validateCurrentStep() : [];
+    if (errors.length > 0) {
+      setMissingFields(errors.map((e) => e.label));
+      setShowValidationModal(true);
+      return;
+    }
+
+    onSaveClick?.();
+  };
+
   return (
     <>
       <ValidationErrorModal
@@ -77,11 +88,7 @@ const ProfileFormNavigation: React.FC<ProfileFormNavigationProps> = ({
               type="submit"
               className="bg-green-600 hover:bg-green-700 w-full sm:w-auto"
               disabled={isSubmitting}
-              onClick={() => {
-                console.log('🔥 ProfileFormNavigation - Profiel Opslaan button clicked!');
-                console.log('🔥 ProfileFormNavigation - isSubmitting:', isSubmitting);
-                onSaveClick?.();
-              }}
+              onClick={handleSave}
             >
               {isSubmitting ? (
                 <>


### PR DESCRIPTION
## Summary
- pass form submit handler to ProfileFormNavigation and validate before saving
- ensure save button triggers provided handler

## Testing
- `npm test`
- `npm run lint` *(fails: 2 errors, 335 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1fa5470832baa1afec20303dcc2