### PR TITLE
chore: remove unused save handler

### DIFF
--- a/src/components/modals/ProfileFormNavigation.tsx
+++ b/src/components/modals/ProfileFormNavigation.tsx
@@ -15,7 +15,6 @@ interface ProfileFormNavigationProps {
   onNext: () => boolean; // returns boolean for validation result
   validateCurrentStep: () => ValidationError[];
   isSubmitting?: boolean;
-  onSaveClick?: () => void;
 }
 
 const ProfileFormNavigation: React.FC<ProfileFormNavigationProps> = ({
@@ -25,7 +24,6 @@ const ProfileFormNavigation: React.FC<ProfileFormNavigationProps> = ({
   onNext,
   validateCurrentStep,
   isSubmitting = false,
-  onSaveClick,
 }) => {
   const [showValidationModal, setShowValidationModal] = useState(false);
   const [missingFields, setMissingFields] = useState<string[]>([]);
@@ -77,11 +75,6 @@ const ProfileFormNavigation: React.FC<ProfileFormNavigationProps> = ({
               type="submit"
               className="bg-green-600 hover:bg-green-700 w-full sm:w-auto"
               disabled={isSubmitting}
-              onClick={() => {
-                console.log('🔥 ProfileFormNavigation - Profiel Opslaan button clicked!');
-                console.log('🔥 ProfileFormNavigation - isSubmitting:', isSubmitting);
-                onSaveClick?.();
-              }}
             >
               {isSubmitting ? (
                 <>


### PR DESCRIPTION
## Summary
- remove unused `onSaveClick` prop and debug logs from `ProfileFormNavigation`

## Testing
- `npm test`
- `npm run lint` *(fails: Header.tsx empty object type, unrelated)*

------
https://chatgpt.com/codex/tasks/task_e_68aefad7f59c832b88ceae7b25afa07d